### PR TITLE
Feat(client): 커뮤니티 링크 컴포넌트 구현

### DIFF
--- a/apps/client/src/widgets/home/community-link/community-link.css.ts
+++ b/apps/client/src/widgets/home/community-link/community-link.css.ts
@@ -11,7 +11,7 @@ export const linkContainer = style({
   borderRadius: '2rem',
   background: themeVars.color.gray100,
   padding: '1.6rem 2rem 1rem 2.2rem',
-  zIndex: 1,
+  zIndex: themeVars.zIndex.content,
 });
 
 export const linkDescription = style({
@@ -26,7 +26,7 @@ export const linkImage = style({
   left: '20rem',
   top: '3rem',
   bottom: '1.6rem',
-  zIndex: 1,
+  zIndex: themeVars.zIndex.content,
 });
 
 export const navigateContainer = style({

--- a/apps/client/src/widgets/home/community-link/community-link.css.ts
+++ b/apps/client/src/widgets/home/community-link/community-link.css.ts
@@ -1,0 +1,44 @@
+import { themeVars } from '@bds/ui/styles';
+import { style } from '@vanilla-extract/css';
+
+export const linkContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '6.8rem',
+  width: '31.1rem',
+  height: '18rem',
+  alignSelf: 'stretch',
+  borderRadius: '2rem',
+  background: themeVars.color.gray100,
+  padding: '1.6rem 2rem 1rem 2.2rem',
+  zIndex: 1,
+});
+
+export const linkDescription = style({
+  ...themeVars.fontStyles.head2_b_18,
+  color: themeVars.color.primary900,
+  whiteSpace: 'pre-wrap',
+});
+
+export const linkImage = style({
+  position: 'absolute',
+  height: '11rem',
+  left: '20rem',
+  top: '3rem',
+  bottom: '1.6rem',
+  zIndex: 1,
+});
+
+export const navigateContainer = style({
+  width: '100%',
+  height: '3.2rem',
+  padding: '0.6rem 0.8rem 0.6rem 1.6rem',
+  gap: '0.4rem',
+  display: 'flex',
+  justifyContent: 'flex-end',
+  cursor: 'pointer',
+});
+
+export const navigateText = style({
+  ...themeVars.fontStyles.title_sb_16,
+});

--- a/apps/client/src/widgets/home/community-link/community-link.css.ts
+++ b/apps/client/src/widgets/home/community-link/community-link.css.ts
@@ -18,15 +18,16 @@ export const linkDescription = style({
   ...themeVars.fontStyles.head2_b_18,
   color: themeVars.color.primary900,
   whiteSpace: 'pre-wrap',
+  zIndex: themeVars.zIndex.content,
 });
 
 export const linkImage = style({
   position: 'absolute',
+  width: '100%',
+  right: '2rem',
   height: '11rem',
-  left: '20rem',
-  top: '3rem',
-  bottom: '1.6rem',
-  zIndex: themeVars.zIndex.content,
+  display: 'flex',
+  justifyContent: 'flex-end',
 });
 
 export const navigateContainer = style({
@@ -41,4 +42,5 @@ export const navigateContainer = style({
 
 export const navigateText = style({
   ...themeVars.fontStyles.title_sb_16,
+  zIndex: themeVars.zIndex.content,
 });

--- a/apps/client/src/widgets/home/community-link/community-link.css.ts
+++ b/apps/client/src/widgets/home/community-link/community-link.css.ts
@@ -5,7 +5,7 @@ export const linkContainer = style({
   display: 'flex',
   flexDirection: 'column',
   gap: '6.8rem',
-  width: '31.1rem',
+  width: '100%',
   height: '18rem',
   alignSelf: 'stretch',
   borderRadius: '2rem',

--- a/apps/client/src/widgets/home/community-link/community-link.tsx
+++ b/apps/client/src/widgets/home/community-link/community-link.tsx
@@ -20,8 +20,10 @@ const CommunityLink = ({ onClick }: CommunityLinkProps) => {
           <dd className={styles.navigateText}>{LINK_DESCRIPTION.NAVIGATE}</dd>
           <Icon name="caret_right_sm" color="primary900" />
         </div>
+        <div className={styles.linkImage}>
+          <img src="./glass_icon_document.webp" />
+        </div>
       </article>
-      <img src="./glass_icon_document.webp" className={styles.linkImage} />
     </>
   );
 };

--- a/apps/client/src/widgets/home/community-link/community-link.tsx
+++ b/apps/client/src/widgets/home/community-link/community-link.tsx
@@ -1,0 +1,29 @@
+import { Icon } from '@bds/ui/icons';
+
+import * as styles from './community-link.css';
+
+const LINK_DESCRIPTION = {
+  TITLE: '보험료, 남들은 얼마나 내는지\n궁금하지 않나요?',
+  NAVIGATE: '커뮤니티로 이동하기',
+};
+
+interface CommunityLinkProps {
+  onClick: VoidFunction;
+}
+
+const CommunityLink = ({ onClick }: CommunityLinkProps) => {
+  return (
+    <>
+      <article className={styles.linkContainer}>
+        <dt className={styles.linkDescription}>{LINK_DESCRIPTION.TITLE}</dt>
+        <div className={styles.navigateContainer} onClick={onClick}>
+          <dd className={styles.navigateText}>{LINK_DESCRIPTION.NAVIGATE}</dd>
+          <Icon name="caret_right_sm" color="primary900" />
+        </div>
+      </article>
+      <img src="./glass_icon_document.webp" className={styles.linkImage} />
+    </>
+  );
+};
+
+export default CommunityLink;

--- a/packages/bds-ui/src/styles/theme.css.ts
+++ b/packages/bds-ui/src/styles/theme.css.ts
@@ -4,6 +4,7 @@ import { createSprinkles, defineProperties } from '@vanilla-extract/sprinkles';
 import { fontStyles } from './tokens/font-style';
 import { typography } from './tokens/typography';
 import { width } from './tokens/width';
+import { zIndex } from './tokens/z-index';
 
 import { color } from './tokens/color.css';
 
@@ -11,6 +12,7 @@ const tokens = {
   color: color,
   fontStyles: fontStyles,
   width: width,
+  zIndex: zIndex,
   ...typography,
 };
 

--- a/packages/bds-ui/src/styles/tokens/z-index.ts
+++ b/packages/bds-ui/src/styles/tokens/z-index.ts
@@ -1,0 +1,4 @@
+export const zIndex = {
+  base: '1',
+  content: '2',
+} as const;


### PR DESCRIPTION
## 📌 Summary

- #92 

## 📚 Tasks

- 커뮤니티 링크 컴포넌트 구현

## 👀 To Reviewer

홈 페이지에서 사용되는 커뮤니티 링크 컴포넌트를 구현했습니다. 피그마 상 정확한 위치 측정이 어려워 absolute 속성을 이용해서 위치를 강제했어요. 

그리고 이미지보다 title 과 navigate 버튼이 높은 zindex 를 가져야해서 zindex 관리의 일관성을 위해 토큰을 추가해두었습니다. 

onClick() interface 를 정의해두어 추후에 홈페이지에서 navigate 핸들러 함수를 넘겨주면 좋을 것 같아요. 

반응형도 모두 확인했습니다.


## 📸 Screenshot

![image](https://github.com/user-attachments/assets/4fba91b2-5886-4705-a150-9a2fcc7e9152)

