### PR TITLE
Refactor(bds): Navigation 컴포넌트 수정

### DIFF
--- a/packages/bds-ui/src/components/index.ts
+++ b/packages/bds-ui/src/components/index.ts
@@ -10,6 +10,7 @@ export { default as ModalContainer } from './modal/modal-container';
 export * from './modal/store/modal-store';
 export { default as Navigation } from './navigation/navigation';
 export { default as Tab } from './tab/tab';
+export { default as TextButton } from './text-button/text-button';
 export { default as ThemeProvider } from './theme-provider';
 export { default as Title } from './title/title';
 export * from './toast/store/toast-store';

--- a/packages/bds-ui/src/components/navigation/navigation.css.ts
+++ b/packages/bds-ui/src/components/navigation/navigation.css.ts
@@ -69,6 +69,8 @@ export const navigationRightVariants = recipe({
     isTextButton: {
       true: {
         padding: 0,
+        position: 'absolute',
+        right: '0.3rem',
       },
       false: {
         padding: '1rem',

--- a/packages/bds-ui/src/components/navigation/navigation.css.ts
+++ b/packages/bds-ui/src/components/navigation/navigation.css.ts
@@ -63,7 +63,6 @@ export const navigationRightVariants = recipe({
     alignItems: 'center',
     justifyContent: 'center',
     height: '100%',
-    padding: '1rem',
     cursor: 'pointer',
   },
   variants: {

--- a/packages/bds-ui/src/components/navigation/navigation.css.ts
+++ b/packages/bds-ui/src/components/navigation/navigation.css.ts
@@ -1,13 +1,15 @@
+import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
 import { themeVars } from '../../styles/theme.css';
 
 export const navigationVariants = recipe({
   base: {
+    position: 'relative',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
-    padding: '0 1.5rem 0 1.2rem',
+    padding: '0 0.3rem 0 0',
     width: '100%',
     height: '4.8rem',
   },
@@ -18,10 +20,6 @@ export const navigationVariants = recipe({
       gradient_primary: { background: themeVars.color.gradientPrimary },
       transparent: { backgroundColor: 'transparent' },
     },
-    hasLeftIcon: {
-      true: { paddingLeft: '1.2rem' },
-      false: { paddingLeft: '3.6rem' },
-    },
   },
   defaultVariants: {
     backgroundColor: 'transparent',
@@ -30,11 +28,12 @@ export const navigationVariants = recipe({
 
 export const titleVariants = recipe({
   base: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    flex: 1,
+    position: 'absolute',
+    left: '50%',
+    top: '50%',
+    transform: 'translate(-50%, -50%)',
     textAlign: 'center',
+    whiteSpace: 'nowrap',
     ...themeVars.fontStyles.title_sb_16,
   },
   variants: {
@@ -45,5 +44,40 @@ export const titleVariants = recipe({
   },
   defaultVariants: {
     color: 'black',
+  },
+});
+
+export const navigationLeft = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '4.8rem',
+  height: '100%',
+  padding: '1rem',
+  cursor: 'pointer',
+});
+
+export const navigationRightVariants = recipe({
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100%',
+    padding: '1rem',
+    cursor: 'pointer',
+  },
+  variants: {
+    isTextButton: {
+      true: {
+        padding: 0,
+      },
+      false: {
+        padding: '1rem',
+        width: '4.8rem',
+      },
+    },
+  },
+  defaultVariants: {
+    isTextButton: false,
   },
 });

--- a/packages/bds-ui/src/components/navigation/navigation.stories.tsx
+++ b/packages/bds-ui/src/components/navigation/navigation.stories.tsx
@@ -1,7 +1,6 @@
+import { Navigation, TextButton } from '@bds/ui';
+import { Icon } from '@bds/ui/icons';
 import type { Meta, StoryObj } from '@storybook/react';
-
-import { Icon } from '../../icons';
-import Navigation from './navigation';
 
 const meta: Meta<typeof Navigation> = {
   title: 'Common/Navigation',
@@ -11,18 +10,26 @@ const meta: Meta<typeof Navigation> = {
     docs: {
       description: {
         component: `
-          상단 Navigation 컴포넌트입니다.
+상단 Navigation 컴포넌트입니다.
 
-          ## Props
-          - **leftIcon**: 좌측 아이콘 요소
-          - **rightIcon**: 우측 아이콘 요소 (필수)
-          - **title**: 타이틀 텍스트
-          - **textColor**: 타이틀 색상 (black | white)
-          - **backgroundColor**: 배경색 (transparent | white | primary | gradient_primary)
+## Props
+- **leftIcon**: 좌측 아이콘 요소
+- **rightIcon**: 우측 아이콘 요소 (필수)
+- **title**: 타이틀 텍스트
+- **textColor**: 타이틀 색상 (black | white)
+- **backgroundColor**: 배경색 (transparent | white | primary | gradient_primary)
+- **isTextButton**: 우측 아이콘 영역이 텍스트 버튼 형태일 경우 true
         `,
       },
     },
   },
+  decorators: [
+    (Story) => (
+      <div style={{ width: '375px', border: '1px solid #eee' }}>
+        <Story />
+      </div>
+    ),
+  ],
   argTypes: {
     leftIcon: {
       description: '좌측에 들어갈 아이콘 컴포넌트',
@@ -50,8 +57,18 @@ const meta: Meta<typeof Navigation> = {
       options: ['transparent', 'white', 'primary', 'gradient_primary'],
       description: '배경 색상',
       table: {
-        type: { summary: 'transparent | white | primary | gradient_primary' },
+        type: {
+          summary: 'transparent | white | primary | gradient_primary',
+        },
         defaultValue: { summary: 'transparent' },
+      },
+    },
+    isTextButton: {
+      control: { type: 'boolean' },
+      description: '우측 버튼이 텍스트 버튼 형태인 경우 true',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
       },
     },
   },
@@ -67,6 +84,7 @@ export const Default: Story = {
     rightIcon: <Icon name="home" color="gray800" />,
     backgroundColor: 'transparent',
     textColor: 'black',
+    isTextButton: false,
   },
   parameters: {
     docs: {
@@ -79,16 +97,17 @@ export const Default: Story = {
 
 export const WithLeftIcon: Story = {
   args: {
-    leftIcon: <Icon name="caret_left_lg" color="gray800" />,
+    leftIcon: <Icon name="arrow_left" />,
     rightIcon: <Icon name="home" color="gray800" />,
     title: '뒤로가기',
     backgroundColor: 'white',
     textColor: 'black',
+    isTextButton: false,
   },
   parameters: {
     docs: {
       description: {
-        story: '좌측에 아이콘(예: 뒤로가기 버튼)이 포함된 Navigation입니다.',
+        story: '좌측에 뒤로가기 아이콘이 포함된 Navigation입니다.',
       },
     },
   },
@@ -98,14 +117,14 @@ export const ColoredBackground: Story = {
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
       <Navigation
-        leftIcon={<Icon name="caret_left_lg" color="gray800" />}
+        leftIcon={<Icon name="arrow_left" />}
         rightIcon={<Icon name="home" color="gray800" />}
         title="Primary 배경"
         backgroundColor="primary"
         textColor="white"
       />
       <Navigation
-        leftIcon={<Icon name="caret_left_lg" color="gray800" />}
+        leftIcon={<Icon name="arrow_left" />}
         rightIcon={<Icon name="home" color="gray800" />}
         title="Gradient 배경"
         backgroundColor="gradient_primary"
@@ -134,14 +153,14 @@ export const TextColors: Story = {
       }}
     >
       <Navigation
-        leftIcon={<Icon name="caret_left_lg" color="white" />}
+        leftIcon={<Icon name="arrow_left" color="white" />}
         rightIcon={<Icon name="home" color="white" />}
         title="White 텍스트"
         backgroundColor="transparent"
         textColor="white"
       />
       <Navigation
-        leftIcon={<Icon name="caret_left_lg" color="gray800" />}
+        leftIcon={<Icon name="arrow_left" color="gray800" />}
         rightIcon={<Icon name="home" color="gray800" />}
         title="Black 텍스트"
         backgroundColor="white"
@@ -153,6 +172,25 @@ export const TextColors: Story = {
     docs: {
       description: {
         story: '텍스트 색상을 black, white로 다르게 설정한 예시입니다.',
+      },
+    },
+  },
+};
+
+export const WithTextButtonRightIcon: Story = {
+  args: {
+    title: '커뮤니티',
+    leftIcon: <Icon name="arrow_left" />,
+    rightIcon: <TextButton color="primary">text</TextButton>,
+    backgroundColor: 'white',
+    textColor: 'black',
+    isTextButton: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`TextButton`을 우측에 사용하고 `isTextButton`을 true로 설정한 예시입니다.',
       },
     },
   },

--- a/packages/bds-ui/src/components/navigation/navigation.tsx
+++ b/packages/bds-ui/src/components/navigation/navigation.tsx
@@ -8,6 +8,7 @@ interface NavigationProps {
   title: ReactNode;
   textColor?: 'black' | 'white';
   backgroundColor?: 'transparent' | 'white' | 'primary' | 'gradient_primary';
+  isTextButton?: boolean;
 }
 
 const Navigation = ({
@@ -16,17 +17,15 @@ const Navigation = ({
   title,
   textColor = 'black',
   backgroundColor = 'transparent',
+  isTextButton = false,
 }: NavigationProps) => {
   return (
-    <nav
-      className={styles.navigationVariants({
-        backgroundColor,
-        hasLeftIcon: !!leftIcon,
-      })}
-    >
-      {leftIcon}
+    <nav className={styles.navigationVariants({ backgroundColor })}>
+      <div className={styles.navigationLeft}>{leftIcon}</div>
       <h1 className={styles.titleVariants({ color: textColor })}>{title}</h1>
-      {rightIcon}
+      <div className={styles.navigationRightVariants({ isTextButton })}>
+        {rightIcon}
+      </div>
     </nav>
   );
 };


### PR DESCRIPTION
## 📌 Summary

- close #130 
<img width="400" height="720" alt="image" src="https://github.com/user-attachments/assets/c86dcb46-a59e-4ebb-9b08-3cfbad6fd788" />

## 📚 Tasks
- leftIcon과 rightIcon을 각각 div로 묶어서 padding을 주었습니다.
- rightIcon에 TextButton이 올 때는 padding: 0이 되어야 합니다. 이를 처리하기 위해서 isTextButton이라는 props를 추가하였습니다.
- isTextButton의 default 값은 false로 기본적인 아이콘을 사용할 때는 해당 props를 안 넘겨도 됩니다. TextButton을 사용할 때만 true 값을 적어주시면 됩니다!
- title은 leftIcon이 있든 없든 화면 가운데에 오게 배치하였습니다.
- index.ts에 TextButton을 추가했습니다.
- (스토리북 수정 예정)

<!--
## 👀 To Reviewer

(기재 내용 없을 경우 섹션 삭제) 더 전달할 내용 혹은 리뷰에게 요청하는 내용을 작성해주세요.
-->

<!--
## 🕶️ Requirements Checklist
- [ ]

(기능 명세서상 내용을 복사해서 테스트해주세요)
-->


## 📸 Screenshot
```typescript
<Navigation
        leftIcon={<Icon name="arrow_left" />}
        rightIcon={<TextButton color="primary">text</TextButton>}
        title="커뮤니티"
        isTextButton={true}
/>

<Navigation
        rightIcon={<Icon name="home" />}
        title="커뮤니티"
/>

<Navigation
        rightIcon={<Icon name="home" color="white" />}
        title="쩡은님 안녕하세요!"
        backgroundColor="primary"
        textColor="white"
/>
```
<img width="250" alt="localhost_5173_(iPhone SE)" src="https://github.com/user-attachments/assets/bd7c14c3-e17f-4d6c-bcf1-18b821507c44" />

<img width="250" height="1334" alt="localhost_5173_(iPhone SE) (1)" src="https://github.com/user-attachments/assets/2e985245-262f-4ea8-bc6b-2f5ebd79defd" />

<img width="250" height="1334" alt="localhost_5173_(iPhone SE) (2)" src="https://github.com/user-attachments/assets/070ec852-d0bd-4775-836e-94d7df316fc4" />

