### PR TITLE
Feat(client): Insurance Title, Subtitle 컴포넌트 구현

### DIFF
--- a/apps/client/src/shared/components/insurance-subtitle/insurance-subtitle.css.ts
+++ b/apps/client/src/shared/components/insurance-subtitle/insurance-subtitle.css.ts
@@ -1,0 +1,23 @@
+import { themeVars } from '@bds/ui/styles';
+import { recipe } from '@vanilla-extract/recipes';
+
+export const subtitleVariants = recipe({
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    width: '100%',
+  },
+  variants: {
+    type: {
+      home: {
+        ...themeVars.fontStyles.title_sb_14,
+        color: themeVars.color.primary100,
+      },
+      report: {
+        ...themeVars.fontStyles.body1_m_16,
+        color: themeVars.color.primary500,
+      },
+    },
+  },
+});

--- a/apps/client/src/shared/components/insurance-subtitle/insurance-subtitle.css.ts
+++ b/apps/client/src/shared/components/insurance-subtitle/insurance-subtitle.css.ts
@@ -9,14 +9,20 @@ export const subtitleVariants = recipe({
     width: '100%',
   },
   variants: {
-    type: {
-      home: {
-        ...themeVars.fontStyles.title_sb_14,
+    fontColor: {
+      primary500: {
+        color: themeVars.color.primary500,
+      },
+      primary100: {
         color: themeVars.color.primary100,
       },
-      report: {
+    },
+    fontStyle: {
+      sb_14: {
+        ...themeVars.fontStyles.title_sb_14,
+      },
+      m_16: {
         ...themeVars.fontStyles.body1_m_16,
-        color: themeVars.color.primary500,
       },
     },
   },

--- a/apps/client/src/shared/components/insurance-subtitle/insurance-subtitle.tsx
+++ b/apps/client/src/shared/components/insurance-subtitle/insurance-subtitle.tsx
@@ -3,6 +3,8 @@ import { subtitleVariants } from './insurance-subtitle.css';
 interface InsuranceSubtitleProps {
   name: string; // TODO 명세 필드명 반영
   type: keyof typeof DEFAULT_PLACEHOLDER;
+  fontColor: 'primary500' | 'primary100';
+  fontStyle: 'm_16' | 'sb_14';
 }
 
 const DEFAULT_PLACEHOLDER = {
@@ -10,9 +12,14 @@ const DEFAULT_PLACEHOLDER = {
   home: '님께 딱 맞는 보험이에요',
 } as const;
 
-const InsuranceSubtitle = ({ type, name }: InsuranceSubtitleProps) => {
+const InsuranceSubtitle = ({
+  type,
+  name,
+  fontColor,
+  fontStyle,
+}: InsuranceSubtitleProps) => {
   return (
-    <h2 className={subtitleVariants({ type })}>
+    <h2 className={subtitleVariants({ fontColor, fontStyle })}>
       {name}
       {DEFAULT_PLACEHOLDER[type]}
     </h2>

--- a/apps/client/src/shared/components/insurance-subtitle/insurance-subtitle.tsx
+++ b/apps/client/src/shared/components/insurance-subtitle/insurance-subtitle.tsx
@@ -12,10 +12,10 @@ const DEFAULT_PLACEHOLDER = {
 
 const InsuranceSubtitle = ({ type, name }: InsuranceSubtitleProps) => {
   return (
-    <h1 className={subtitleVariants({ type })}>
+    <h2 className={subtitleVariants({ type })}>
       {name}
       {DEFAULT_PLACEHOLDER[type]}
-    </h1>
+    </h2>
   );
 };
 

--- a/apps/client/src/shared/components/insurance-subtitle/insurance-subtitle.tsx
+++ b/apps/client/src/shared/components/insurance-subtitle/insurance-subtitle.tsx
@@ -1,0 +1,22 @@
+import { subtitleVariants } from './insurance-subtitle.css';
+
+interface InsuranceSubtitleProps {
+  name: string; // API 연동
+  type: keyof typeof DEFAULT_PLACEHOLDER;
+}
+
+const DEFAULT_PLACEHOLDER = {
+  report: '님께 추천드리는 보험은',
+  home: '님께 딱 맞는 보험이에요',
+} as const;
+
+const InsuranceSubtitle = ({ type, name }: InsuranceSubtitleProps) => {
+  return (
+    <h1 className={subtitleVariants({ type })}>
+      {name}
+      {DEFAULT_PLACEHOLDER[type]}
+    </h1>
+  );
+};
+
+export default InsuranceSubtitle;

--- a/apps/client/src/shared/components/insurance-subtitle/insurance-subtitle.tsx
+++ b/apps/client/src/shared/components/insurance-subtitle/insurance-subtitle.tsx
@@ -1,7 +1,7 @@
 import { subtitleVariants } from './insurance-subtitle.css';
 
 interface InsuranceSubtitleProps {
-  name: string; // API 연동
+  name: string; // TODO 명세 필드명 반영
   type: keyof typeof DEFAULT_PLACEHOLDER;
 }
 

--- a/apps/client/src/shared/components/insurance-title/insurance-title.css.ts
+++ b/apps/client/src/shared/components/insurance-title/insurance-title.css.ts
@@ -1,0 +1,29 @@
+import { themeVars } from '@bds/ui/styles';
+import { recipe } from '@vanilla-extract/recipes';
+
+export const titleVariants = recipe({
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    width: '100%',
+  },
+  variants: {
+    size: {
+      md: {
+        ...themeVars.fontStyles.head_eb_24,
+      },
+      lg: {
+        ...themeVars.fontStyles.head_eb_28,
+      },
+    },
+    color: {
+      white: {
+        color: themeVars.color.white,
+      },
+      black: {
+        color: themeVars.color.gray900,
+      },
+    },
+  },
+});

--- a/apps/client/src/shared/components/insurance-title/insurance-title.css.ts
+++ b/apps/client/src/shared/components/insurance-title/insurance-title.css.ts
@@ -7,6 +7,7 @@ export const titleVariants = recipe({
     flexDirection: 'column',
     alignItems: 'flex-start',
     width: '100%',
+    whiteSpace: 'pre-line',
   },
   variants: {
     fontColor: {

--- a/apps/client/src/shared/components/insurance-title/insurance-title.css.ts
+++ b/apps/client/src/shared/components/insurance-title/insurance-title.css.ts
@@ -9,14 +9,20 @@ export const titleVariants = recipe({
     width: '100%',
   },
   variants: {
-    type: {
-      report: {
-        ...themeVars.fontStyles.head_eb_24,
+    fontColor: {
+      gray900: {
         color: themeVars.color.gray900,
       },
-      home: {
-        ...themeVars.fontStyles.head_eb_28,
+      white: {
         color: themeVars.color.white,
+      },
+    },
+    fontStyle: {
+      eb_md: {
+        ...themeVars.fontStyles.head_eb_24,
+      },
+      eb_lg: {
+        ...themeVars.fontStyles.head_eb_28,
       },
     },
   },

--- a/apps/client/src/shared/components/insurance-title/insurance-title.css.ts
+++ b/apps/client/src/shared/components/insurance-title/insurance-title.css.ts
@@ -18,10 +18,10 @@ export const titleVariants = recipe({
       },
     },
     fontStyle: {
-      eb_md: {
+      eb_24: {
         ...themeVars.fontStyles.head_eb_24,
       },
-      eb_lg: {
+      eb_28: {
         ...themeVars.fontStyles.head_eb_28,
       },
     },

--- a/apps/client/src/shared/components/insurance-title/insurance-title.css.ts
+++ b/apps/client/src/shared/components/insurance-title/insurance-title.css.ts
@@ -9,20 +9,14 @@ export const titleVariants = recipe({
     width: '100%',
   },
   variants: {
-    size: {
-      md: {
+    type: {
+      report: {
         ...themeVars.fontStyles.head_eb_24,
-      },
-      lg: {
-        ...themeVars.fontStyles.head_eb_28,
-      },
-    },
-    color: {
-      white: {
-        color: themeVars.color.white,
-      },
-      black: {
         color: themeVars.color.gray900,
+      },
+      home: {
+        ...themeVars.fontStyles.head_eb_28,
+        color: themeVars.color.white,
       },
     },
   },

--- a/apps/client/src/shared/components/insurance-title/insurance-title.tsx
+++ b/apps/client/src/shared/components/insurance-title/insurance-title.tsx
@@ -3,12 +3,18 @@ import { titleVariants } from './insurance-title.css';
 interface InsuranceTitleProps {
   company: string; // TODO 명세 필드명 반영
   name: string; // TODO 명세 필드명 반영
-  type: 'report' | 'home';
+  fontColor: 'gray900' | 'white';
+  fontStyle: 'eb_md' | 'eb_lg';
 }
 
-const InsuranceTitle = ({ company, name, type }: InsuranceTitleProps) => {
+const InsuranceTitle = ({
+  company,
+  name,
+  fontColor,
+  fontStyle,
+}: InsuranceTitleProps) => {
   return (
-    <h1 className={titleVariants({ type })}>
+    <h1 className={titleVariants({ fontColor, fontStyle })}>
       {company}의<br /> {name}
     </h1>
   );

--- a/apps/client/src/shared/components/insurance-title/insurance-title.tsx
+++ b/apps/client/src/shared/components/insurance-title/insurance-title.tsx
@@ -15,11 +15,12 @@ const InsuranceTitle = ({
   fontColor,
   fontStyle,
 }: InsuranceTitleProps) => {
+  const TITLE = `${company}의\n${name}`;
   const hasContent = company && name;
 
   return (
     <h1 className={titleVariants({ fontColor, fontStyle })}>
-      {hasContent ? `${company}의\n${name}` : DEFAULT_PLACEHOLDER}
+      {hasContent ? TITLE : DEFAULT_PLACEHOLDER}
     </h1>
   );
 };

--- a/apps/client/src/shared/components/insurance-title/insurance-title.tsx
+++ b/apps/client/src/shared/components/insurance-title/insurance-title.tsx
@@ -1,11 +1,13 @@
 import { titleVariants } from './insurance-title.css';
 
 interface InsuranceTitleProps {
-  company: string; // TODO 명세 필드명 반영
-  name: string; // TODO 명세 필드명 반영
+  company?: string; // TODO 명세 필드명 반영
+  name?: string; // TODO 명세 필드명 반영
   fontColor: 'gray900' | 'white';
   fontStyle: 'eb_24' | 'eb_28';
 }
+
+const DEFAULT_PLACEHOLDER = '보험, 어디서부터 시작해야\n할지 막막하다면?';
 
 const InsuranceTitle = ({
   company,
@@ -13,9 +15,11 @@ const InsuranceTitle = ({
   fontColor,
   fontStyle,
 }: InsuranceTitleProps) => {
+  const hasContent = company && name;
+
   return (
     <h1 className={titleVariants({ fontColor, fontStyle })}>
-      {company}의<br /> {name}
+      {hasContent ? `${company}의\n${name}` : DEFAULT_PLACEHOLDER}
     </h1>
   );
 };

--- a/apps/client/src/shared/components/insurance-title/insurance-title.tsx
+++ b/apps/client/src/shared/components/insurance-title/insurance-title.tsx
@@ -1,8 +1,8 @@
 import { titleVariants } from './insurance-title.css';
 
 interface InsuranceTitleProps {
-  company: string; //api 연동
-  name: string; //api 연동
+  company: string; // TODO 명세 필드명 반영
+  name: string; // TODO 명세 필드명 반영
   type: 'report' | 'home';
 }
 

--- a/apps/client/src/shared/components/insurance-title/insurance-title.tsx
+++ b/apps/client/src/shared/components/insurance-title/insurance-title.tsx
@@ -3,18 +3,12 @@ import { titleVariants } from './insurance-title.css';
 interface InsuranceTitleProps {
   company: string; //api 연동
   name: string; //api 연동
-  size: 'md' | 'lg';
-  color: 'white' | 'black';
+  type: 'report' | 'home';
 }
 
-const InsuranceTitle = ({
-  company,
-  name,
-  size,
-  color,
-}: InsuranceTitleProps) => {
+const InsuranceTitle = ({ company, name, type }: InsuranceTitleProps) => {
   return (
-    <h1 className={titleVariants({ size, color })}>
+    <h1 className={titleVariants({ type })}>
       {company}의<br /> {name}
     </h1>
   );

--- a/apps/client/src/shared/components/insurance-title/insurance-title.tsx
+++ b/apps/client/src/shared/components/insurance-title/insurance-title.tsx
@@ -4,7 +4,7 @@ interface InsuranceTitleProps {
   company: string; // TODO 명세 필드명 반영
   name: string; // TODO 명세 필드명 반영
   fontColor: 'gray900' | 'white';
-  fontStyle: 'eb_md' | 'eb_lg';
+  fontStyle: 'eb_24' | 'eb_28';
 }
 
 const InsuranceTitle = ({

--- a/apps/client/src/shared/components/insurance-title/insurance-title.tsx
+++ b/apps/client/src/shared/components/insurance-title/insurance-title.tsx
@@ -1,0 +1,23 @@
+import { titleVariants } from './insurance-title.css';
+
+interface InsuranceTitleProps {
+  company: string; //api 연동
+  name: string; //api 연동
+  size: 'md' | 'lg';
+  color: 'white' | 'black';
+}
+
+const InsuranceTitle = ({
+  company,
+  name,
+  size,
+  color,
+}: InsuranceTitleProps) => {
+  return (
+    <h1 className={titleVariants({ size, color })}>
+      {company}의<br /> {name}
+    </h1>
+  );
+};
+
+export default InsuranceTitle;


### PR DESCRIPTION
## 📌 Summary

- close #137 
-  보험 추천 report 상단 부분과 home에서 사용되는 Insurance Title, Subtitle 컴포넌트를 구현하였습니다.

## 📚 Tasks
- report 상단 부분과 home에서만 사용되는 컴포넌트이기 떄문에, color와 size를 받는 대신 type을 home 또는 report로 지정할 수 있도록 하였습니다.
- subtitle의 DEFAULT_PLACEHOLDER 안에 report와 home은 `type: keyof typeof DEFAULT_PLACEHOLDER;`을 사용하기 위해 소문자로 지정하였는데, 대문자로 바꿔야 한다면 수정하도록 하겠습니다.
- 사용 예시는 아래에 스크린샷과 첨부하도록 하겠습니다.


> shared/components/insurance-title
<img width="686" height="144" alt="Image" src="https://github.com/user-attachments/assets/1c01e474-8068-487f-9174-8ac264e3c38a" />

> shared/components/insurance-subtitle
<img width="342" height="29" alt="Image" src="https://github.com/user-attachments/assets/8b3e7370-286e-4436-9884-fdf347622436" />



<!--
## 👀 To Reviewer

(기재 내용 없을 경우 섹션 삭제) 더 전달할 내용 혹은 리뷰에게 요청하는 내용을 작성해주세요.
-->

<!--
## 🕶️ Requirements Checklist
- [ ]

(기능 명세서상 내용을 복사해서 테스트해주세요)
-->


## 📸 Screenshot
```typescript
<InsuranceTitle company="OO보험사" name="OO보험" type="report" />
```
<img width="350" alt="localhost_5173_(iPhone SE)" src="https://github.com/user-attachments/assets/07f03c9f-a01a-4247-a2e3-0e1e08935bb8" />

```typescript
<InsuranceSubtitle name="OO" type="report" />

<InsuranceSubtitle name="OO" type="home" />
```
<img width="350" alt="localhost_5173_(iPhone SE) (2)" src="https://github.com/user-attachments/assets/b79e93db-1658-4b49-8e79-8e04f998d3d7" />

<img width="350" alt="localhost_5173_(iPhone SE) (1)" src="https://github.com/user-attachments/assets/ac95859f-18bb-4aae-ad4b-25bd3e7966ec" />


