### PR TITLE
Feat(client): Maturity, Price 컴포넌트 구현

### DIFF
--- a/apps/client/src/widgets/report/components/maturity/maturity.css.ts
+++ b/apps/client/src/widgets/report/components/maturity/maturity.css.ts
@@ -1,0 +1,10 @@
+import { themeVars } from '@bds/ui/styles';
+import { style } from '@vanilla-extract/css';
+
+export const maturityContainer = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.2rem',
+  color: themeVars.color.gray600,
+  ...themeVars.fontStyles.title_sb_14,
+});

--- a/apps/client/src/widgets/report/components/maturity/maturity.tsx
+++ b/apps/client/src/widgets/report/components/maturity/maturity.tsx
@@ -1,0 +1,22 @@
+import * as styles from './maturity.css';
+
+interface MaturityProps {
+  age: number; // api 연동
+}
+
+const MATURITY = '만기';
+const AGE = '세';
+
+const Title = ({ age }: MaturityProps) => {
+  return (
+    <div className={styles.maturityContainer}>
+      <p>{MATURITY}</p>
+      <p>
+        {age}
+        {AGE}
+      </p>
+    </div>
+  );
+};
+
+export default Title;

--- a/apps/client/src/widgets/report/components/price/price.css.ts
+++ b/apps/client/src/widgets/report/components/price/price.css.ts
@@ -1,0 +1,19 @@
+import { themeVars } from '@bds/ui/styles';
+import { style } from '@vanilla-extract/css';
+
+export const priceContainer = style({
+  display: 'flex',
+  height: '3rem',
+  alignItems: 'center',
+  justifyContent: 'flex-end',
+  color: themeVars.color.primary500,
+  ...themeVars.fontStyles.head_eb_20,
+});
+
+export const month = style({
+  marginRight: '0.4rem',
+});
+
+export const price = style({
+  marginRight: '0.2em',
+});

--- a/apps/client/src/widgets/report/components/price/price.tsx
+++ b/apps/client/src/widgets/report/components/price/price.tsx
@@ -1,0 +1,20 @@
+import * as styles from './price.css';
+
+interface PriceProps {
+  price: number; // api 연동
+}
+
+const MONTH = '월';
+const WON = '원';
+
+const Title = ({ price }: PriceProps) => {
+  return (
+    <div className={styles.priceContainer}>
+      <p className={styles.month}>{MONTH}</p>
+      <p className={styles.price}>{price}</p>
+      <p>{WON}</p>
+    </div>
+  );
+};
+
+export default Title;


### PR DESCRIPTION
## 📌 Summary

- close #142 
- 보험 추천 report 상단 부분에서 사용되는 Maturity, Price 컴포넌트를 구현하였습니다.

## 📚 Tasks
- 현재 price와 age 모두 number로 타입을 지정해두었는데, price는 천 단위마다 쉼표(,)를 넣는 유틸 함수를 사용할 예정이라 추후에 string으로 바뀔 가능성이 있습니다!

> widgets/report/components/maturity
<img width="128" height="40" alt="image" src="https://github.com/user-attachments/assets/060caa6f-60a7-4fc1-89bb-a098b1476a76" />

> widgets/report/components/price
<img width="226" height="60" alt="image" src="https://github.com/user-attachments/assets/bab643ef-d23b-47e6-9477-7b2e784f47dd" />



<!--
## 👀 To Reviewer

(기재 내용 없을 경우 섹션 삭제) 더 전달할 내용 혹은 리뷰에게 요청하는 내용을 작성해주세요.
-->

<!--
## 🕶️ Requirements Checklist
- [ ]

(기능 명세서상 내용을 복사해서 테스트해주세요)
-->


## 📸 Screenshot
```typescript
<Price price={53479} />
<Maturity age={100} />
```

<img width="350" height="1334" alt="localhost_5173_(iPhone SE) (4)" src="https://github.com/user-attachments/assets/2660baf7-8f39-4beb-ab63-59e75d9309e9" />

<img width="350" height="1334" alt="localhost_5173_(iPhone SE) (3)" src="https://github.com/user-attachments/assets/3cc34d88-9258-4c17-97ea-0aafa9d539da" />
