### PR TITLE
Feat(bds): textbutton 의 white variant 추가

### DIFF
--- a/packages/bds-ui/src/components/text-button/text-button.css.ts
+++ b/packages/bds-ui/src/components/text-button/text-button.css.ts
@@ -5,17 +5,36 @@ import { themeVars } from '../../styles';
 export const base = style({
   padding: '0.6rem 1.6rem',
   ...themeVars.fontStyles.title_sb_16,
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.8rem',
 });
 
 export const buttonColor = styleVariants({
   black: [
     base,
     {
-      color: themeVars.color.gray800,
+      color: themeVars.color.gray900,
 
       selectors: {
         '&:not(:disabled):active': {
           color: themeVars.color.gray700,
+        },
+        '&:disabled': {
+          color: themeVars.color.gray400,
+        },
+      },
+    },
+  ],
+
+  white: [
+    base,
+    {
+      color: themeVars.color.white,
+
+      selectors: {
+        '&:not(:disabled):active': {
+          color: themeVars.color.gray100,
         },
         '&:disabled': {
           color: themeVars.color.gray400,

--- a/packages/bds-ui/src/components/text-button/text-button.css.ts
+++ b/packages/bds-ui/src/components/text-button/text-button.css.ts
@@ -34,7 +34,7 @@ export const buttonColor = styleVariants({
 
       selectors: {
         '&:not(:disabled):active': {
-          color: themeVars.color.gray100,
+          color: themeVars.color.primary100,
         },
         '&:disabled': {
           color: themeVars.color.gray400,

--- a/packages/bds-ui/src/components/text-button/text-button.stories.tsx
+++ b/packages/bds-ui/src/components/text-button/text-button.stories.tsx
@@ -82,3 +82,11 @@ export const DisabledPrimary: Story = {
     children: '비활성 프라이머리',
   },
 };
+
+export const White: Story = {
+  name: 'white',
+  args: {
+    color: 'white',
+    children: '화이트 버튼',
+  },
+};

--- a/packages/bds-ui/src/components/text-button/text-button.tsx
+++ b/packages/bds-ui/src/components/text-button/text-button.tsx
@@ -4,7 +4,7 @@ import { buttonColor } from './text-button.css';
 
 interface TextButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: ReactNode;
-  color: 'black' | 'primary';
+  color: 'black' | 'primary' | 'white';
   disabled?: boolean;
 }
 


### PR DESCRIPTION
## 📌 Summary

> - #149

text button 의 variant 를 추가합니다. 

## 📚 Tasks

디자인에게 요청해서 또 디자인을 받아왔어요. 

<img width="449" height="486" alt="스크린샷 2025-07-12 03 34 23" src="https://github.com/user-attachments/assets/87591667-74ca-4f64-b669-fab006aaba79" />


## 📸 Screenshot


textButton 아이콘이 없는 버전 

<img width="390" height="259" alt="스크린샷 2025-07-11 22 42 42" src="https://github.com/user-attachments/assets/ecaa6796-3695-4771-bbad-4780a0df0414" />

textButton 아이콘이 있는 버전 

<img width="311" height="125" alt="스크린샷 2025-07-11 22 42 51" src="https://github.com/user-attachments/assets/2b0d8536-ac8e-429f-9c94-dc3669be0eb9" />

-> 두 버전을 모두 커버하기 위해 display flex 를 주었습니다. align 맞추고 gap 도 주었어요. 



