### PR TITLE
Feat(client): Basic Info Section 컴포넌트 구현

### DIFF
--- a/apps/client/src/widgets/onboarding/components/basic-info-secction/basic-info-section.css.ts
+++ b/apps/client/src/widgets/onboarding/components/basic-info-secction/basic-info-section.css.ts
@@ -1,0 +1,50 @@
+import { style } from '@vanilla-extract/css';
+
+import { themeVars } from '@bds/ui/styles';
+
+export const basicContainer = style({
+  width: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+  gap: '4rem',
+  alignSelf: 'stretch',
+});
+
+export const fieldContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  width: '100%',
+  gap: '1.2rem',
+});
+
+export const fieldNameLabel = style({
+  color: themeVars.color.gray900,
+  ...themeVars.fontStyles.head2_b_16,
+});
+
+export const birthdateContainer = style({
+  width: '100%',
+  display: 'flex',
+  justifyContent: 'space-between',
+});
+
+export const birthInputContainer = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.8em',
+});
+
+export const birthdateInput = style({
+  width: '9rem',
+});
+
+export const birthdateLabel = style({
+  color: themeVars.color.gray800,
+  ...themeVars.fontStyles.body1_m_14,
+});
+
+export const buttonContainer = style({
+  display: 'flex',
+  gap: '0.7rem',
+});

--- a/apps/client/src/widgets/onboarding/components/basic-info-secction/basic-info-section.tsx
+++ b/apps/client/src/widgets/onboarding/components/basic-info-secction/basic-info-section.tsx
@@ -1,0 +1,238 @@
+import { useReducer } from 'react';
+
+import { Button, Input } from '@bds/ui';
+
+import DropDown from '../dropdown/dropdown';
+
+import * as styles from './basic-info-section.css';
+
+const LABEL = {
+  NAME: '이름',
+  BIRTHDATE: '생년월일',
+  GENDER: '성별',
+  OCCUPATION: '어떤 직업에 종사하고 계신가요?',
+  MARRIED: '기혼자이신가요?',
+  CHILD: '자녀가 있으신가요?',
+  DRIVER: '운전하시나요?',
+};
+
+const OPTION = {
+  YES: '예',
+  NO: '아니오',
+  MALE: '남성',
+  FEMALE: '여성',
+  NAME_PLACEHOLDER: '이름을 작성해주세요.',
+  YEAR: '년',
+  MONTH: '월',
+  DAY: '일',
+};
+
+type State = {
+  name: string;
+  birthYear: string;
+  birthMonth: string;
+  birthDay: string;
+  gender: '남성' | '여성' | null;
+  isMarried: boolean | null;
+  hasChild: boolean | null;
+  isDriver: boolean | null;
+};
+
+type Action =
+  | { type: 'SET_NAME'; payload: string }
+  | { type: 'SET_BIRTH_YEAR'; payload: string }
+  | { type: 'SET_BIRTH_MONTH'; payload: string }
+  | { type: 'SET_BIRTH_DAY'; payload: string }
+  | { type: 'SET_GENDER'; payload: '남성' | '여성' }
+  | { type: 'SET_IS_MARRIED'; payload: boolean }
+  | { type: 'SET_HAS_CHILD'; payload: boolean }
+  | { type: 'SET_IS_DRIVER'; payload: boolean };
+
+const initialState: State = {
+  name: '',
+  birthYear: '',
+  birthMonth: '',
+  birthDay: '',
+  gender: '여성',
+  isMarried: false,
+  hasChild: false,
+  isDriver: false,
+};
+
+const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case 'SET_NAME':
+      return { ...state, name: action.payload };
+    case 'SET_BIRTH_YEAR':
+      return { ...state, birthYear: action.payload };
+    case 'SET_BIRTH_MONTH':
+      return { ...state, birthMonth: action.payload };
+    case 'SET_BIRTH_DAY':
+      return { ...state, birthDay: action.payload };
+    case 'SET_GENDER':
+      return { ...state, gender: action.payload };
+    case 'SET_IS_MARRIED':
+      return { ...state, isMarried: action.payload };
+    case 'SET_HAS_CHILD':
+      return { ...state, hasChild: action.payload };
+    case 'SET_IS_DRIVER':
+      return { ...state, isDriver: action.payload };
+    default:
+      return state;
+  }
+};
+
+const BasicInfoSection = () => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  return (
+    <section className={styles.basicContainer}>
+      <div className={styles.fieldContainer}>
+        <p className={styles.fieldNameLabel}>{LABEL.NAME}</p>
+        <Input
+          value={state.name}
+          onChange={(e) =>
+            dispatch({ type: 'SET_NAME', payload: e.target.value })
+          }
+          bgColor="background"
+          placeholder={OPTION.NAME_PLACEHOLDER}
+        />
+      </div>
+
+      <div className={styles.fieldContainer}>
+        <p className={styles.fieldNameLabel}>{LABEL.BIRTHDATE}</p>
+        <div className={styles.birthdateContainer}>
+          <div className={styles.birthInputContainer}>
+            <div className={styles.birthdateInput}>
+              <Input
+                value={state.birthYear}
+                onChange={(e) =>
+                  dispatch({ type: 'SET_BIRTH_YEAR', payload: e.target.value })
+                }
+                placeholder="YYYY"
+                maxLength={4}
+                bgColor="background"
+              />
+            </div>
+            <span className={styles.birthdateLabel}>{OPTION.YEAR}</span>
+          </div>
+          <div className={styles.birthInputContainer}>
+            <div className={styles.birthdateInput}>
+              <Input
+                value={state.birthMonth}
+                onChange={(e) =>
+                  dispatch({ type: 'SET_BIRTH_MONTH', payload: e.target.value })
+                }
+                placeholder="MM"
+                maxLength={2}
+                bgColor="background"
+              />
+            </div>
+            <span className={styles.birthdateLabel}>{OPTION.MONTH}</span>
+          </div>
+          <div className={styles.birthInputContainer}>
+            <div className={styles.birthdateInput}>
+              <Input
+                value={state.birthDay}
+                onChange={(e) =>
+                  dispatch({ type: 'SET_BIRTH_DAY', payload: e.target.value })
+                }
+                placeholder="DD"
+                maxLength={2}
+                bgColor="background"
+              />
+            </div>
+            <span className={styles.birthdateLabel}>{OPTION.DAY}</span>
+          </div>
+        </div>
+      </div>
+
+      <div className={styles.fieldContainer}>
+        <p className={styles.fieldNameLabel}>{LABEL.GENDER}</p>
+        <div className={styles.buttonContainer}>
+          <Button
+            size="lg"
+            variant={state.gender === '남성' ? 'selected' : 'unselected'}
+            onClick={() => dispatch({ type: 'SET_GENDER', payload: '남성' })}
+          >
+            {OPTION.MALE}
+          </Button>
+          <Button
+            size="lg"
+            variant={state.gender === '여성' ? 'selected' : 'unselected'}
+            onClick={() => dispatch({ type: 'SET_GENDER', payload: '여성' })}
+          >
+            {OPTION.FEMALE}
+          </Button>
+        </div>
+      </div>
+
+      <div className={styles.fieldContainer}>
+        <p className={styles.fieldNameLabel}>{LABEL.OCCUPATION}</p>
+        <DropDown />
+      </div>
+
+      <div className={styles.fieldContainer}>
+        <p className={styles.fieldNameLabel}>{LABEL.MARRIED}</p>
+        <div className={styles.buttonContainer}>
+          <Button
+            size="lg"
+            variant={state.isMarried === true ? 'selected' : 'unselected'}
+            onClick={() => dispatch({ type: 'SET_IS_MARRIED', payload: true })}
+          >
+            {OPTION.YES}
+          </Button>
+          <Button
+            size="lg"
+            variant={state.isMarried === false ? 'selected' : 'unselected'}
+            onClick={() => dispatch({ type: 'SET_IS_MARRIED', payload: false })}
+          >
+            {OPTION.NO}
+          </Button>
+        </div>
+      </div>
+
+      <div className={styles.fieldContainer}>
+        <p className={styles.fieldNameLabel}>{LABEL.CHILD}</p>
+        <div className={styles.buttonContainer}>
+          <Button
+            size="lg"
+            variant={state.hasChild === true ? 'selected' : 'unselected'}
+            onClick={() => dispatch({ type: 'SET_HAS_CHILD', payload: true })}
+          >
+            {OPTION.YES}
+          </Button>
+          <Button
+            size="lg"
+            variant={state.hasChild === false ? 'selected' : 'unselected'}
+            onClick={() => dispatch({ type: 'SET_HAS_CHILD', payload: false })}
+          >
+            {OPTION.NO}
+          </Button>
+        </div>
+      </div>
+
+      <div className={styles.fieldContainer}>
+        <p className={styles.fieldNameLabel}>{LABEL.DRIVER}</p>
+        <div className={styles.buttonContainer}>
+          <Button
+            size="lg"
+            variant={state.isDriver === true ? 'selected' : 'unselected'}
+            onClick={() => dispatch({ type: 'SET_IS_DRIVER', payload: true })}
+          >
+            {OPTION.YES}
+          </Button>
+          <Button
+            size="lg"
+            variant={state.isDriver === false ? 'selected' : 'unselected'}
+            onClick={() => dispatch({ type: 'SET_IS_DRIVER', payload: false })}
+          >
+            {OPTION.NO}
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default BasicInfoSection;

--- a/apps/client/src/widgets/report/components/divider/divider.css.ts
+++ b/apps/client/src/widgets/report/components/divider/divider.css.ts
@@ -1,5 +1,6 @@
-import { themeVars } from '@bds/ui/styles';
 import { style } from '@vanilla-extract/css';
+
+import { themeVars } from '@bds/ui/styles';
 
 export const dividerContainer = style({
   display: 'flex',

--- a/packages/bds-ui/src/components/button/button.css.ts
+++ b/packages/bds-ui/src/components/button/button.css.ts
@@ -86,6 +86,25 @@ export const buttonVariants = styleVariants({
       },
     },
   ],
+
+  selected: [
+    base,
+    {
+      color: themeVars.color.primary500,
+      border: `1px solid ${themeVars.color.primary500}`,
+      backgroundColor: themeVars.color.primary100,
+      transition: 'background-color 0.15s ease',
+    },
+  ],
+
+  unselected: [
+    base,
+    {
+      color: themeVars.color.gray400,
+      border: `1px solid ${themeVars.color.gray300}`,
+      transition: 'background-color 0.15s ease',
+    },
+  ],
 });
 
 export const buttonSizes = styleVariants({

--- a/packages/bds-ui/src/components/input/input.css.ts
+++ b/packages/bds-ui/src/components/input/input.css.ts
@@ -26,6 +26,9 @@ export const container = recipe({
       white: {
         backgroundColor: themeVars.color.white,
       },
+      background: {
+        backgroundColor: themeVars.color.whiteBackground,
+      },
     },
 
     hasError: {

--- a/packages/bds-ui/src/components/input/input.tsx
+++ b/packages/bds-ui/src/components/input/input.tsx
@@ -31,7 +31,7 @@ import * as styles from './input.css';
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   value: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  bgColor: 'gray' | 'white';
+  bgColor: 'gray' | 'white' | 'background';
   placeholder: string;
   errorState?: boolean;
 }


### PR DESCRIPTION
## 📌 Summary

- close #163 
- 정보입력 페이지 중 첫 번째 단계인 기본 정보 입력 컴포넌트를 구현합니다.
<img width="250" src="https://github.com/user-attachments/assets/6b8bf3af-9240-40c7-b7cb-3279c41bb42b" />

## 📚 Tasks

- 이름 (Input)
- 생년월일 (Input)
- 성별 (Button)
- 어떤 직업에 종사하고 계신가요? (Dropbox)
- 기혼자이신가요? (Button)
- 자녀가 있으신가요? (Button)
- 운전하시나요? (Button)

## 👀 To Reviewer
> 디자인팀과 의논한 사항 (리뷰 시 참고 부탁드립니다)
- 생년월일의 Input 3개 모두 width를 9rem으로 지정하였습니다. (SE 기준으로 맞춤)
- 피그마 상에서는 생년월일의 Input 글씨가 가운데 정렬되어있는데, 현재로서는 Input 컴포넌트를 수정하기 어려워 이대로 두기로 하였습니다.
- Button 컴포넌트 transition은 0.15s로 지정하였습니다.

> 추가 내용
- Button 컴포넌트 사용하는 부분은 모두 오른쪽이 default 입니다.
- 스토리북은 추후에 수정할 예정입니다.

<!--
## 🕶️ Requirements Checklist
- [ ]

(기능 명세서상 내용을 복사해서 테스트해주세요)
-->

## 📸 Screenshot
<img width="250" src="https://github.com/user-attachments/assets/e6acbba8-55e1-43b8-b625-93cddb4c580b" />

- BasicInfoSection 컴포넌트를 페이지에서 불러 사용할 예정이라 현재는 padding이 안 들어있는데, 실제 사용했을 때의 화면을 보여주기 위해 `padding: '2rem'`을 추가해놨습니다. (코드에는 없습니다!)