### PR TITLE
Feat(client): 보험 추천 리포트 페이지 퍼블리싱

### DIFF
--- a/apps/client/src/pages/report/report-page.css.ts
+++ b/apps/client/src/pages/report/report-page.css.ts
@@ -1,0 +1,7 @@
+import { style } from '@vanilla-extract/css';
+
+import { themeVars } from '@bds/ui/styles';
+
+export const container = style({
+  backgroundColor: themeVars.color.whiteBackground,
+});

--- a/apps/client/src/pages/report/report-page.tsx
+++ b/apps/client/src/pages/report/report-page.tsx
@@ -1,5 +1,14 @@
+import ReportDetail from '@widgets/report/components/report-detail/report-detail';
+import Summarize from '@widgets/report/components/summarize/summarize';
+
+import * as styles from './report-page.css';
 const ReportPage = () => {
-  return <div>ReportPage</div>;
+  return (
+    <div className={styles.container}>
+      <Summarize />
+      <ReportDetail />
+    </div>
+  );
 };
 
 export default ReportPage;

--- a/apps/client/src/pages/report/report-page.tsx
+++ b/apps/client/src/pages/report/report-page.tsx
@@ -1,10 +1,36 @@
+import { useNavigate } from 'react-router';
+
+import { Navigation } from '@bds/ui';
+import { Icon } from '@bds/ui/icons';
+
 import ReportDetail from '@widgets/report/components/report-detail/report-detail';
 import Summarize from '@widgets/report/components/summarize/summarize';
 
+import { routePath } from '@shared/router/path';
+
 import * as styles from './report-page.css';
+
+const HEADER_TEXT = '보험 추천 리포트';
+
 const ReportPage = () => {
+  const navigate = useNavigate();
+
+  const handleNavigate = (path: string) => {
+    navigate(path);
+  };
+
   return (
     <div className={styles.container}>
+      <Navigation
+        rightIcon={
+          <Icon
+            name="home"
+            color="gray800"
+            onClick={() => handleNavigate(routePath.HOME)}
+          />
+        }
+        title={HEADER_TEXT}
+      />
       <Summarize />
       <ReportDetail />
     </div>

--- a/apps/client/src/pages/report/report-page.tsx
+++ b/apps/client/src/pages/report/report-page.tsx
@@ -22,6 +22,7 @@ const ReportPage = () => {
   return (
     <div className={styles.container}>
       <Navigation
+        backgroundColor="white"
         rightIcon={
           <Icon
             name="home"

--- a/apps/client/src/widgets/report/components/accordion/accordion.css.ts
+++ b/apps/client/src/widgets/report/components/accordion/accordion.css.ts
@@ -24,10 +24,23 @@ export const headerContentsContainer = style({
   width: '100%',
 });
 
-export const iconContainer = style({
-  display: 'flex',
-  alignItems: 'center',
-  cursor: 'pointer',
+export const iconContainer = recipe({
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    cursor: 'pointer',
+    transition: 'transform 0.25s ease-in-out',
+  },
+  variants: {
+    expanded: {
+      true: {
+        transform: 'rotate(180deg)',
+      },
+      false: {
+        transform: 'rotate(0deg)',
+      },
+    },
+  },
 });
 
 export const panelContainer = recipe({

--- a/apps/client/src/widgets/report/components/accordion/accordion.tsx
+++ b/apps/client/src/widgets/report/components/accordion/accordion.tsx
@@ -43,13 +43,8 @@ export const AccordionHeader = ({ children, type }: accordionHeaderProps) => {
         <Title category="mainCategory" title={children} />
         <Chip type={type} />
       </div>
-      <div className={styles.iconContainer} onClick={handleClick}>
-        <Icon
-          name="caret_down_lg"
-          size="2.4rem"
-          color="gray800"
-          rotate={expanded ? 180 : undefined}
-        />
+      <div className={styles.iconContainer({ expanded })} onClick={handleClick}>
+        <Icon name="caret_down_lg" size="2.4rem" color="gray800" />
       </div>
     </div>
   );

--- a/apps/client/src/widgets/report/components/report-detail/report-detail.css.ts
+++ b/apps/client/src/widgets/report/components/report-detail/report-detail.css.ts
@@ -6,8 +6,16 @@ export const container = style({
   padding: '0 1.6rem 2.4rem 1.6rem',
 });
 
-export const tabContainer = style({
-  margin: '1.6rem 0',
+export const section = style({
+  scrollMarginTop: '7.2rem',
+});
+
+export const tabStickyContainer = style({
+  position: 'sticky',
+  top: 0,
+  zIndex: 10,
+  backgroundColor: themeVars.color.whiteBackground,
+  padding: '1.6rem 0',
 });
 
 export const bottomTextContainer = style({

--- a/apps/client/src/widgets/report/components/report-detail/report-detail.css.ts
+++ b/apps/client/src/widgets/report/components/report-detail/report-detail.css.ts
@@ -3,7 +3,7 @@ import { style } from '@vanilla-extract/css';
 import { themeVars } from '@bds/ui/styles';
 
 export const container = style({
-  padding: '0 1.6rem 2.4rem 1.6rem',
+  padding: '1.6rem 1.6rem 2.4rem 1.6rem',
 });
 
 export const section = style({
@@ -15,7 +15,7 @@ export const tabStickyContainer = style({
   top: 0,
   zIndex: 10,
   backgroundColor: themeVars.color.whiteBackground,
-  padding: '1.6rem 0',
+  paddingTop: '1.6rem',
 });
 
 export const bottomTextContainer = style({
@@ -34,7 +34,8 @@ export const subText = style({
 export const homeText = style({
   ...themeVars.fontStyles.title_sb_18,
   color: themeVars.color.gray800,
-  marginTop: '1.6rem',
   cursor: 'pointer',
   width: 'fit-content',
+  padding: '1rem 1.6rem',
+  marginTop: '0.8rem',
 });

--- a/apps/client/src/widgets/report/components/report-detail/report-detail.css.ts
+++ b/apps/client/src/widgets/report/components/report-detail/report-detail.css.ts
@@ -1,0 +1,32 @@
+import { style } from '@vanilla-extract/css';
+
+import { themeVars } from '@bds/ui/styles';
+
+export const container = style({
+  padding: '0 1.6rem 2.4rem 1.6rem',
+});
+
+export const tabContainer = style({
+  margin: '1.6rem 0',
+});
+
+export const bottomTextContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+});
+
+export const subText = style({
+  ...themeVars.fontStyles.body2_r_14,
+  color: themeVars.color.gray800,
+  textAlign: 'center',
+  marginBottom: '1.6rem',
+});
+
+export const homeText = style({
+  ...themeVars.fontStyles.title_sb_18,
+  color: themeVars.color.gray800,
+  marginTop: '1.6rem',
+  cursor: 'pointer',
+  width: 'fit-content',
+});

--- a/apps/client/src/widgets/report/components/report-detail/report-detail.tsx
+++ b/apps/client/src/widgets/report/components/report-detail/report-detail.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { useNavigate } from 'react-router';
 
 import { Button, Tab } from '@bds/ui';
@@ -10,13 +11,7 @@ import Susul from '../susul/susul';
 
 import * as styles from './report-detail.css';
 
-const TAB_TITLE = [
-  { TITLE: '큰 병' },
-  { TITLE: '수술' },
-  { TITLE: '입원' },
-  { TITLE: '장해' },
-  { TITLE: '사망' },
-];
+const TAB_TITLE = ['큰 병', '수술', '입원', '장해', '사망'];
 
 const TEXT = {
   BUTTON_TEXT: '더 자세한 보장 알아보기',
@@ -27,26 +22,56 @@ const TEXT = {
 const ReportDetail = () => {
   const navigate = useNavigate();
 
+  const keunbyeongRef = useRef<HTMLDivElement>(null);
+  const susulRef = useRef<HTMLDivElement>(null);
+  const ipwonRef = useRef<HTMLDivElement>(null);
+  const janghaeRef = useRef<HTMLDivElement>(null);
+  const samangRef = useRef<HTMLDivElement>(null);
+
+  const ELEMENT_REFS = [
+    keunbyeongRef,
+    susulRef,
+    ipwonRef,
+    janghaeRef,
+    samangRef,
+  ];
+
+  const tabList = TAB_TITLE.map((title, idx) => ({
+    title,
+    ref: ELEMENT_REFS[idx],
+  }));
+
   const handleClick = () => {
     navigate('/');
   };
+
   return (
     <>
       <Tab.Container initialValue="큰병">
         <div className={styles.tabContainer}>
           <Tab.List>
-            {TAB_TITLE.map(({ TITLE }, index) => (
-              <Tab.Item key={index} value={TITLE} />
+            {tabList.map(({ title, ref }, index) => (
+              <Tab.Item key={index} value={title} scrollTarget={ref} />
             ))}
           </Tab.List>
         </div>
       </Tab.Container>
       <div className={styles.container}>
-        <Keunbyeong />
-        <Susul />
-        <Ipwon />
-        <Janghae />
-        <Samang />
+        <div ref={keunbyeongRef}>
+          <Keunbyeong />
+        </div>
+        <div ref={susulRef}>
+          <Susul />
+        </div>
+        <div ref={ipwonRef}>
+          <Ipwon />
+        </div>
+        <div ref={janghaeRef}>
+          <Janghae />
+        </div>
+        <div ref={samangRef}>
+          <Samang />
+        </div>
         <div className={styles.bottomTextContainer}>
           <p className={styles.subText}>{TEXT.SUB_TEXT}</p>
           <Button size="lg">{TEXT.BUTTON_TEXT}</Button>

--- a/apps/client/src/widgets/report/components/report-detail/report-detail.tsx
+++ b/apps/client/src/widgets/report/components/report-detail/report-detail.tsx
@@ -50,7 +50,7 @@ const ReportDetail = () => {
   return (
     <div ref={keunbyeongRef}>
       <div className={styles.tabStickyContainer}>
-        <Tab.Container initialValue="큰병">
+        <Tab.Container initialValue="큰 병">
           <Tab.List>
             {tabList.map(({ title, ref }, index) => (
               <Tab.Item key={index} value={title} scrollTarget={ref} />
@@ -59,7 +59,9 @@ const ReportDetail = () => {
         </Tab.Container>
       </div>
       <div className={styles.container}>
-        <Keunbyeong />
+        <div ref={keunbyeongRef} className={styles.section}>
+          <Keunbyeong />
+        </div>
         <div ref={susulRef} className={styles.section}>
           <Susul />
         </div>

--- a/apps/client/src/widgets/report/components/report-detail/report-detail.tsx
+++ b/apps/client/src/widgets/report/components/report-detail/report-detail.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from 'react-router';
 
 import { Button, Tab } from '@bds/ui';
 
+import { routePath } from '@shared/router/path';
+
 import Ipwon from '../ipwon/ipwon';
 import Janghae from '../janghae/janghae';
 import Keunbyeong from '../keunbyeong/keunbyeong';
@@ -42,7 +44,7 @@ const ReportDetail = () => {
   }));
 
   const handleClick = () => {
-    navigate('/');
+    navigate(routePath.HOME);
   };
 
   return (

--- a/apps/client/src/widgets/report/components/report-detail/report-detail.tsx
+++ b/apps/client/src/widgets/report/components/report-detail/report-detail.tsx
@@ -1,7 +1,8 @@
-import { useRef } from 'react';
 import { useNavigate } from 'react-router';
 
 import { Button, Tab } from '@bds/ui';
+
+import { useMoveScroll } from '@widgets/report/hooks/use-move-scroll';
 
 import { routePath } from '@shared/router/path';
 
@@ -13,7 +14,13 @@ import Susul from '../susul/susul';
 
 import * as styles from './report-detail.css';
 
-const TAB_TITLE = ['큰 병', '수술', '입원', '장해', '사망'];
+const SECTIONS = [
+  { key: 'keunbyeongRef', title: '큰 병', Component: Keunbyeong },
+  { key: 'susulRef', title: '수술', Component: Susul },
+  { key: 'ipwonRef', title: '입원', Component: Ipwon },
+  { key: 'janghaeRef', title: '장해', Component: Janghae },
+  { key: 'samangRef', title: '사망', Component: Samang },
+] as const;
 
 const TEXT = {
   BUTTON_TEXT: '더 자세한 보장 알아보기',
@@ -24,56 +31,43 @@ const TEXT = {
 const ReportDetail = () => {
   const navigate = useNavigate();
 
-  const keunbyeongRef = useRef<HTMLDivElement>(null);
-  const susulRef = useRef<HTMLDivElement>(null);
-  const ipwonRef = useRef<HTMLDivElement>(null);
-  const janghaeRef = useRef<HTMLDivElement>(null);
-  const samangRef = useRef<HTMLDivElement>(null);
-
-  const ELEMENT_REFS = [
-    keunbyeongRef,
-    susulRef,
-    ipwonRef,
-    janghaeRef,
-    samangRef,
-  ];
-
-  const tabList = TAB_TITLE.map((title, idx) => ({
-    title,
-    ref: ELEMENT_REFS[idx],
-  }));
+  const scrollRefs = {
+    keunbyeongRef: useMoveScroll(),
+    susulRef: useMoveScroll(),
+    ipwonRef: useMoveScroll(),
+    janghaeRef: useMoveScroll(),
+    samangRef: useMoveScroll(),
+  };
 
   const handleClick = () => {
     navigate(routePath.HOME);
   };
 
   return (
-    <div ref={keunbyeongRef}>
+    <div>
       <div className={styles.tabStickyContainer}>
         <Tab.Container initialValue="큰 병">
           <Tab.List>
-            {tabList.map(({ title, ref }, index) => (
-              <Tab.Item key={index} value={title} scrollTarget={ref} />
+            {SECTIONS.map(({ key, title }) => (
+              <Tab.Item
+                key={key}
+                value={title}
+                scrollTarget={scrollRefs[key].element}
+              />
             ))}
           </Tab.List>
         </Tab.Container>
       </div>
       <div className={styles.container}>
-        <div ref={keunbyeongRef} className={styles.section}>
-          <Keunbyeong />
-        </div>
-        <div ref={susulRef} className={styles.section}>
-          <Susul />
-        </div>
-        <div ref={ipwonRef} className={styles.section}>
-          <Ipwon />
-        </div>
-        <div ref={janghaeRef} className={styles.section}>
-          <Janghae />
-        </div>
-        <div ref={samangRef} className={styles.section}>
-          <Samang />
-        </div>
+        {SECTIONS.map(({ key, Component }) => (
+          <section
+            key={key}
+            ref={scrollRefs[key].element}
+            className={styles.section}
+          >
+            <Component />
+          </section>
+        ))}
         <div className={styles.bottomTextContainer}>
           <p className={styles.subText}>{TEXT.SUB_TEXT}</p>
           <Button size="lg">{TEXT.BUTTON_TEXT}</Button>

--- a/apps/client/src/widgets/report/components/report-detail/report-detail.tsx
+++ b/apps/client/src/widgets/report/components/report-detail/report-detail.tsx
@@ -46,30 +46,28 @@ const ReportDetail = () => {
   };
 
   return (
-    <>
-      <Tab.Container initialValue="큰병">
-        <div className={styles.tabContainer}>
+    <div ref={keunbyeongRef}>
+      <div className={styles.tabStickyContainer}>
+        <Tab.Container initialValue="큰병">
           <Tab.List>
             {tabList.map(({ title, ref }, index) => (
               <Tab.Item key={index} value={title} scrollTarget={ref} />
             ))}
           </Tab.List>
-        </div>
-      </Tab.Container>
+        </Tab.Container>
+      </div>
       <div className={styles.container}>
-        <div ref={keunbyeongRef}>
-          <Keunbyeong />
-        </div>
-        <div ref={susulRef}>
+        <Keunbyeong />
+        <div ref={susulRef} className={styles.section}>
           <Susul />
         </div>
-        <div ref={ipwonRef}>
+        <div ref={ipwonRef} className={styles.section}>
           <Ipwon />
         </div>
-        <div ref={janghaeRef}>
+        <div ref={janghaeRef} className={styles.section}>
           <Janghae />
         </div>
-        <div ref={samangRef}>
+        <div ref={samangRef} className={styles.section}>
           <Samang />
         </div>
         <div className={styles.bottomTextContainer}>
@@ -80,7 +78,7 @@ const ReportDetail = () => {
           </button>
         </div>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/apps/client/src/widgets/report/components/report-detail/report-detail.tsx
+++ b/apps/client/src/widgets/report/components/report-detail/report-detail.tsx
@@ -1,0 +1,62 @@
+import { useNavigate } from 'react-router';
+
+import { Button, Tab } from '@bds/ui';
+
+import Ipwon from '../ipwon/ipwon';
+import Janghae from '../janghae/janghae';
+import Keunbyeong from '../keunbyeong/keunbyeong';
+import Samang from '../samang/samang';
+import Susul from '../susul/susul';
+
+import * as styles from './report-detail.css';
+
+const TAB_TITLE = [
+  { TITLE: '큰 병' },
+  { TITLE: '수술' },
+  { TITLE: '입원' },
+  { TITLE: '장해' },
+  { TITLE: '사망' },
+];
+
+const TEXT = {
+  BUTTON_TEXT: '더 자세한 보장 알아보기',
+  SUB_TEXT: '이 보험에 관심이 있다면',
+  HOME_TEXT: '홈으로',
+};
+
+const ReportDetail = () => {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate('/');
+  };
+  return (
+    <>
+      <Tab.Container initialValue="큰병">
+        <div className={styles.tabContainer}>
+          <Tab.List>
+            {TAB_TITLE.map(({ TITLE }, index) => (
+              <Tab.Item key={index} value={TITLE} />
+            ))}
+          </Tab.List>
+        </div>
+      </Tab.Container>
+      <div className={styles.container}>
+        <Keunbyeong />
+        <Susul />
+        <Ipwon />
+        <Janghae />
+        <Samang />
+        <div className={styles.bottomTextContainer}>
+          <p className={styles.subText}>{TEXT.SUB_TEXT}</p>
+          <Button size="lg">{TEXT.BUTTON_TEXT}</Button>
+          <button className={styles.homeText} onClick={handleClick}>
+            {TEXT.HOME_TEXT}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ReportDetail;

--- a/apps/client/src/widgets/report/components/samang/samang.css.ts
+++ b/apps/client/src/widgets/report/components/samang/samang.css.ts
@@ -1,7 +1,7 @@
 import { style } from '@vanilla-extract/css';
 
 export const container = style({
-  paddingBottom: '7.2rem',
+  paddingBottom: '4.5rem',
 });
 
 export const contentContainer = style({

--- a/apps/client/src/widgets/report/components/summarize/summarize.css.ts
+++ b/apps/client/src/widgets/report/components/summarize/summarize.css.ts
@@ -6,6 +6,8 @@ export const summarizeContainer = style({
   width: '100%',
   display: 'flex',
   position: 'relative',
+  background: themeVars.color.white,
+  borderRadius: '0 0 28px 28px',
 });
 
 export const backgroundImage = style({

--- a/apps/client/src/widgets/report/hooks/use-move-scroll.tsx
+++ b/apps/client/src/widgets/report/hooks/use-move-scroll.tsx
@@ -1,0 +1,9 @@
+import { useRef } from 'react';
+
+export const useMoveScroll = () => {
+  const element = useRef<HTMLDivElement | null>(null);
+  const onMoveToElement = () => {
+    element.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  };
+  return { element, onMoveToElement };
+};

--- a/packages/bds-ui/src/components/navigation/navigation.css.ts
+++ b/packages/bds-ui/src/components/navigation/navigation.css.ts
@@ -15,7 +15,7 @@ export const navigationVariants = recipe({
   },
   variants: {
     backgroundColor: {
-      white: { backgroundColor: themeVars.color.whiteBackground },
+      white: { backgroundColor: themeVars.color.white },
       primary: { backgroundColor: themeVars.color.primary500 },
       gradient_primary: { background: themeVars.color.gradientPrimary },
       transparent: { backgroundColor: 'transparent' },

--- a/packages/bds-ui/src/components/tab/tab.tsx
+++ b/packages/bds-ui/src/components/tab/tab.tsx
@@ -16,6 +16,7 @@ interface ListProps {
 
 interface ItemProps {
   value: string;
+  scrollTarget?: React.RefObject<HTMLDivElement | null>;
 }
 
 interface PanelProps {
@@ -45,12 +46,13 @@ const List = ({ children }: ListProps) => {
   return <ul className={styles.tabList}>{children}</ul>;
 };
 
-const Item = ({ value }: ItemProps) => {
+const Item = ({ value, scrollTarget }: ItemProps) => {
   const { selectedTab, setSelectedTab, tabRefs } = useTabContext();
   const isSelected = value === selectedTab;
 
   const handleClick = () => {
     setSelectedTab(value);
+    scrollTarget?.current?.scrollIntoView({ behavior: 'smooth' });
   };
 
   return (


### PR DESCRIPTION
## 📌 Summary

- close #175 

보험 추천 리포트 페이지 퍼블리싱을 구현합니다.

## 📚 Tasks

- 구현한 컴포넌트 병합
- Tab Category 클릭 시 자동 스크롤 구현
- 보험 상세 정보 나타날 시 Tab 고정
- Tab 컴포넌트 자동 스크롤 수정
- 아코디언 열림/닫힘 시 화살표 애니메이션 구현

## 👀 To Reviewer
여태까지 구현한 컴포넌트를 합치고 최종 보험 추천 리포트 페이지를 구현하였습니다.
ReportDetail 페이지에서 Tab 클릭 시 자동 스크롤 되는 로직이 조금 복잡한 것 같은데 더 수월한 구조 말씀해주시면 감사하겠습니다...

추가적으로 처음 페이지가 렌더링 될 때

<img width="494" height="85" alt="image" src="https://github.com/user-attachments/assets/ff168f0a-e15d-479c-8854-3f40f967b832" />

</br>
</br>

<!--
## 🕶️ Requirements Checklist
- [ ]

(기능 명세서상 내용을 복사해서 테스트해주세요)
-->

## 📸 Screenshot


https://github.com/user-attachments/assets/2f9c3415-2897-495e-a307-db4adcb9b121



