### PR TITLE
Fix(client): Floating 버튼 집나가는 문제 해결

### DIFF
--- a/apps/client/src/pages/community/community-page.css.ts
+++ b/apps/client/src/pages/community/community-page.css.ts
@@ -20,3 +20,17 @@ export const mapCommunityListContainer = style({
   padding: '2.4rem 1.6rem 0',
   gap: '1.6rem',
 });
+
+export const bottomFloating = style({
+  position: 'fixed',
+  bottom: '2.4rem',
+  right: '50%',
+  transform: 'translateX(199px)',
+
+  '@media': {
+    'screen and (max-width: 430px)': {
+      right: '1.6rem',
+      transform: 'none',
+    },
+  },
+});

--- a/apps/client/src/pages/community/community-page.tsx
+++ b/apps/client/src/pages/community/community-page.tsx
@@ -69,11 +69,13 @@ const CommunityPage = () => {
         )}
       </article>
 
-      <Floating
-        icon={<Icon name="edit" width={'100%'} height={'100%'} />}
-        state="default"
-        onClick={onClick}
-      />
+      <div className={styles.bottomFloating}>
+        <Floating
+          icon={<Icon name="edit" width={'100%'} height={'100%'} />}
+          state="default"
+          onClick={onClick}
+        />
+      </div>
     </div>
   );
 };

--- a/packages/bds-ui/src/components/floating/floating.css.ts
+++ b/packages/bds-ui/src/components/floating/floating.css.ts
@@ -4,7 +4,6 @@ import { recipe, RecipeVariants } from '@vanilla-extract/recipes';
 import { themeVars } from '../../styles';
 
 export const baseButton = style({
-  position: 'fixed',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
@@ -12,8 +11,7 @@ export const baseButton = style({
   height: '5.6rem',
   borderRadius: '50px',
   flexShrink: 0,
-  bottom: '2.4rem',
-  right: '1.6rem',
+
   selectors: {
     '&:not(:disabled):active': {
       background: themeVars.color.primary600,


### PR DESCRIPTION
## 📌 Summary

> -#197

Floating 버튼이 밖으로 나가는 문제를 해결합니다.

## 📚 Tasks

[ 기본 Floating 버튼 의 position 제거 ] 

bds Floating 버튼은 그저 ui 에 불가 하기 때문에 position 은 밖에서 세팅하도록 해야한다고 생각했어요. 
왜냐하면 해당 Floating 이 어디서 또 쓰일지 모르는데, position absolute 와 함께 bottom, right 가 함께 지정이 되어있으면 그 장소에서만 사용이 가능해지는 문제가 있어요. 그래서 position 과 bottom, right 는 제거했습니다. 

[ community 에서의 floating 버튼이 영역 밖을 넘어가는 문제 ] 

저희 화면은 max 430 px 입니다. 
이를 반으로 쪼개면 215 px 입니다. 
가운데를 기준으로 오른쪽으로 215px 간 다음, 
왼쪽으로 16px 만큼 가야해요. (플로팅 버튼과 오른쪽 벽의 간격) 

계산해보면 
우선 left : 50% 세팅을 합니다. -> 요소를 화면의 가운데로 위치해요. 
그리고 X 좌표로 215 - 16  = 199px 만큼 오른쪽으로 보내주었습니다. 

그리고 나서 이제 screen 크기가 430 이하일때가
또 위치 계산이 달라져야 합니다. 
transform 을 없애고 오른쪽에서 16px 만큼만 오도록 미디어 쿼리를 줬어요. 



## 📸 Screenshot


https://github.com/user-attachments/assets/251fe32b-fef9-4c6b-ba68-2075cbf013a4


