### PR TITLE
Feat(client): 스크롤 move 관련 hook 추가

### DIFF
--- a/apps/client/src/shared/hooks/use-move-scroll.ts
+++ b/apps/client/src/shared/hooks/use-move-scroll.ts
@@ -1,0 +1,16 @@
+import { useEffect, useRef } from 'react';
+
+export const useScrollIntoViewOnOpen = (isOpen: boolean, offset = 20) => {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (isOpen && ref.current) {
+      const rect = ref.current.getBoundingClientRect();
+      const scrollTop = window.scrollY + rect.top - offset;
+
+      window.scrollTo({ top: scrollTop, behavior: 'smooth' });
+    }
+  }, [isOpen, offset]);
+
+  return ref;
+};

--- a/apps/client/src/widgets/onboarding/components/dropdown/dropdown.tsx
+++ b/apps/client/src/widgets/onboarding/components/dropdown/dropdown.tsx
@@ -1,9 +1,10 @@
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 
 import { Icon } from '@bds/ui/icons';
 
 import { UserInfoJobList } from '@shared/api/types/types';
 import useClickOutside from '@shared/hooks/use-click-outside';
+import { useScrollIntoViewOnOpen } from '@shared/hooks/use-move-scroll';
 
 import OptionItem from './option-item';
 
@@ -19,7 +20,7 @@ const DEFAULT_PLACEHOLDER = '직업을 선택해주세요.';
 
 const DropDown = ({ selected, onSelect, jobs }: DropDownProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
+  const ref = useScrollIntoViewOnOpen(isOpen, 48);
 
   useClickOutside(ref, () => setIsOpen(false), isOpen);
 


### PR DESCRIPTION
## 📌 Summary

- #217
## 📚 Tasks
> 만든 이유

정보입력에서 드롭다운이 열리고 닫힐 때 현재 뷰포트 상단 가까이 위치해서 사용자 경험을 높이고 싶었어요.
그래서 드롭다운이 열릴 때 자동으로 컴포넌트 위치를 계산해 스크롤 이동하는 커스텀 훅을 만들었습니다.

> 코드

isOpen 상태가 true로 변할 때마다 useEffect가 실행됩니다. 
ref.current가 실제 DOM 엘리먼트를 가리키고 있으면, 그 요소의 화면 내 위치 (getBoundingClientRect())를 얻습니다.
현재 페이지의 스크롤 위치(window.scrollY)와 요소 위치를 계산해서 적절한 오프셋 만큼 여유를 두고 스크롤 위치를 조정합니다. window.scrollTo의 behavior: 'smooth' 옵션을 사용해 자연스러운 스크롤 이동을 구현합니다.
offset 값을 받아서 스크롤 위치를 조금 더 위로 띄워서 고정된 헤더나 여백을 고려할 수 있게 했습니다.

> 사용

```ts
const Dropdown = ({ isOpen }) => {
  const ref = useScrollIntoViewOnOpen(isOpen);
  //   const ref = useScrollIntoViewOnOpen(isOpen, 48);

  return (
    <div ref={ref}>
      {/* 드롭다운 내용 */}
    </div>
  );
};

```

## 📸 Screenshot

https://github.com/user-attachments/assets/3fbc35eb-05bd-4131-8c17-8bc833ec38b0



