### PR TITLE
Fix(client): suspense 로딩이 전역적으로 적용이 되지 않는 문제 해결

### DIFF
--- a/apps/client/src/pages/home/home-page.tsx
+++ b/apps/client/src/pages/home/home-page.tsx
@@ -11,6 +11,8 @@ import { routePath } from '@shared/router/path.ts';
 
 import * as styles from './home-page.css.ts';
 
+import 'swiper/swiper-bundle.css';
+
 const HomePage = () => {
   const navigate = useNavigate();
   const isRecommended = true;

--- a/apps/client/src/shared/router/global-layout.tsx
+++ b/apps/client/src/shared/router/global-layout.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from 'react';
 import {
   matchPath,
   Outlet,
@@ -18,10 +17,8 @@ export default function GlobalLayout() {
   );
   return (
     <div className={`${isLayoutFree ? noRootShadow : rootStyle}`}>
-      <Suspense>
-        <Outlet />
-        <ScrollRestoration />
-      </Suspense>
+      <Outlet />
+      <ScrollRestoration />
     </div>
   );
 }

--- a/apps/client/src/shared/router/layout-free-layout.tsx
+++ b/apps/client/src/shared/router/layout-free-layout.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from 'react';
 import { Outlet, ScrollRestoration } from 'react-router-dom';
 
 import { noRootShadow } from '@bds/ui/styles';
@@ -6,10 +5,8 @@ import { noRootShadow } from '@bds/ui/styles';
 export default function layoutFreeLayout() {
   return (
     <div className={noRootShadow}>
-      <Suspense>
-        <Outlet />
-        <ScrollRestoration />
-      </Suspense>
+      <Outlet />
+      <ScrollRestoration />
     </div>
   );
 }

--- a/apps/client/src/shared/router/lazy.ts
+++ b/apps/client/src/shared/router/lazy.ts
@@ -1,3 +1,28 @@
 import { lazy } from 'react';
 
 export const HomePage = lazy(() => import('@pages/home/home-page'));
+
+export const OnboardingPage = lazy(
+  () => import('@pages/onboarding/onboarding-page'),
+);
+
+export const CommunityPage = lazy(
+  () => import('@pages/community/community-page'),
+);
+export const CommunityWrite = lazy(
+  () => import('@pages/community/community-write/community-write'),
+);
+export const CommunityDetail = lazy(
+  () => import('@pages/community/community-detail/community-detail'),
+);
+
+export const MyPage = lazy(() => import('@pages/my/my-page'));
+
+export const ReportPage = lazy(() => import('@pages/report/report-page'));
+
+export const LoginPage = lazy(() => import('@pages/login/login-page'));
+export const LoginFallbackPage = lazy(
+  () => import('@pages/login-fallback/login-fallback-page'),
+);
+
+export const SplashPage = lazy(() => import('@pages/splash/splash-page'));

--- a/apps/client/src/shared/router/lazy.ts
+++ b/apps/client/src/shared/router/lazy.ts
@@ -24,5 +24,3 @@ export const LoginPage = lazy(() => import('@pages/login/login-page'));
 export const LoginFallbackPage = lazy(
   () => import('@pages/login-fallback/login-fallback-page'),
 );
-
-export const SplashPage = lazy(() => import('@pages/splash/splash-page'));

--- a/apps/client/src/shared/router/routes/global-routes.tsx
+++ b/apps/client/src/shared/router/routes/global-routes.tsx
@@ -1,3 +1,5 @@
+import SplashPage from '@pages/splash/splash-page.tsx';
+
 import {
   CommunityDetail,
   CommunityPage,
@@ -8,7 +10,6 @@ import {
   MyPage,
   OnboardingPage,
   ReportPage,
-  SplashPage,
 } from '../lazy';
 import { routePath } from '../path';
 

--- a/apps/client/src/shared/router/routes/global-routes.tsx
+++ b/apps/client/src/shared/router/routes/global-routes.tsx
@@ -1,14 +1,15 @@
-import CommunityDetail from '@pages/community/community-detail/community-detail';
-import CommunityPage from '@pages/community/community-page';
-import CommunityWrite from '@pages/community/community-write/community-write';
-import LoginPage from '@pages/login/login-page.tsx';
-import LoginFallbackPage from '@pages/login-fallback/login-fallback-page.tsx';
-import MyPage from '@pages/my/my-page.tsx';
-import OnboardingPage from '@pages/onboarding/onboarding-page.tsx';
-import ReportPage from '@pages/report/report-page.tsx';
-import SplashPage from '@pages/splash/splash-page.tsx';
-
-import { HomePage } from '../lazy';
+import {
+  CommunityDetail,
+  CommunityPage,
+  CommunityWrite,
+  HomePage,
+  LoginFallbackPage,
+  LoginPage,
+  MyPage,
+  OnboardingPage,
+  ReportPage,
+  SplashPage,
+} from '../lazy';
 import { routePath } from '../path';
 
 // 공개 라우트 (인증 불필요)

--- a/apps/client/src/widgets/home/components/features-section/features-section.css.ts
+++ b/apps/client/src/widgets/home/components/features-section/features-section.css.ts
@@ -49,6 +49,6 @@ export const slideItem = style({
 });
 
 export const tipList = style({
-  padding: '0 1.6rem',
+  padding: '0 1.6rem !important',
   height: '118px !important',
 });

--- a/apps/client/src/widgets/home/components/features-section/features-section.tsx
+++ b/apps/client/src/widgets/home/components/features-section/features-section.tsx
@@ -46,7 +46,6 @@ export const FeaturesSection = () => {
           speed={500}
           modules={[Pagination]}
           centeredSlides={false}
-          pagination={{ clickable: true }}
           onSlideChange={(swiper) => setCurrentPage(swiper.realIndex)}
           onReachEnd={() => setCurrentPage(2)}
           className={styles.tipList}

--- a/apps/client/src/widgets/home/components/info-section/recommended-info-section.css.ts
+++ b/apps/client/src/widgets/home/components/info-section/recommended-info-section.css.ts
@@ -30,11 +30,11 @@ export const chipList = style({
 
 export const homeChipList = style({
   overflowX: 'auto',
-  paddingBottom: '2.2rem',
 });
 
 globalStyle(`${homeChipList}  .swiper-wrapper`, {
   transitionTimingFunction: 'linear',
+  paddingBottom: '2.2rem',
 });
 
 export const homeChipIcon = style({


### PR DESCRIPTION
## 📌 Summary

> - #220


## 📚 Tasks

**[ suspense 로딩이 전역적으로 적용이 되지 않는 문제 해결 ]** 

### 로딩 UI 안보였던 이유

suspense 가 먹지 않는 이유는 lazy import 되지 않아서 였어요. 

저희 원래코드는 다음과 같습니다. 

```ts
<Suspense fallback={<Loading />}>
  {/* 동기적으로 로드 */}
  <MyComponent />
</Suspense>
```
-> 이 구조에서는 전혀 Loading 이 보여질 방법이 없었어요. 
[_Suspense 는 자식 컴포넌트의 비동기 로딩 (suspend) 상태를 감지해야만 fallback UI 를 표시_](https://ko.react.dev/reference/react/Suspense#displaying-a-fallback-while-content-is-loading%23) 하기 때문에 <Mycomponent /> 처럼 동기적으로 즉시 렌더링되는 컴포넌트는 로딩 중이라는 신호를 주지 않기 때문에 로딩 상태라고 인식하지 못하고 바로 내용을 렌더링 해서 보여지지 않았습니다. 


### 해결방법

그래서 모든 페이지 컴포넌트를 지연 로딩하도록 리펙토링 했어요. 


`export const HomePage = lazy(() => import('@pages/home/home-page'));
`

그리고 Suspense 경계 내에서 `<MyComponent /> ` 대신 `<LazyPage />` 를 렌더링하도록 했습니다. 이때 Suspense 구성은 이전과 동일하게 유지하여, 로딩 중에 `<Loading />` 컴포넌트를 보여주도록 했습니다.

글로벌 레이아웃 등에 fallback이 없는 Suspense 경계 제거: 최상위에서 로딩 UI를 제공하지 않던 Suspense들을 모두 삭제하거나 적절한 fallback을 갖도록 조정했습니다. 이를 통해 실제 로딩 상태에서는 하위 Suspense의 fallback이 화면에 제대로 나타날 수 있게 되었습니다.


### 좀 더 톺아보자면

React.lazy 를 도입하면서 문제가 해결된 이유는 React.lazy 가 컴포넌트 코드를 동적으로 불러오는 Promise 를 반환하기 때문입니다. 
React 는 Lazy 컴포넌트를 렌더링 하려 할 때 아직 코드가 로드되지 않았다면 내부적으로 그 Promise 에 **pending** 상태를 감지하여 렌더링을 **일시 중단(suspense)** 시킵니다. 

이 때 Suspense 는 해당 Promise 가 해결될 때까지 Fallback 으로 전달된 컴포넌트를 화면에 표시하게 됩니다. -> Loading 

공식문서 첨부해둘게요 
[_“lazy는 트리에 렌더링할 수 있는 React 컴포넌트를 반환합니다. 컴포넌트의 코드가 여전히 로딩되는 동안 렌더링을 시도하면 일시 중지됩니다. 로딩 중에 Loading Indicator를 표시하려면 <Suspense> 를 사용하세요.”_ ](https://ko.react.dev/reference/react/lazy#:~:text=,Suspense%3E%EB%A5%BC%20%EC%82%AC%EC%9A%A9%ED%95%98%EC%84%B8%EC%9A%94)



## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요시 .gif 형식으로 첨부해주세요.


https://github.com/user-attachments/assets/b8cfaf9f-3477-4a9e-b163-3004d717ae70

