### PR TITLE
Feat(client): home 페이지 user Info api 연동 

### DIFF
--- a/apps/client/src/pages/home/home-page.tsx
+++ b/apps/client/src/pages/home/home-page.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
 import { Navigation } from '@bds/ui';
@@ -7,6 +8,7 @@ import { FeaturesSection } from '@widgets/home/components/features-section/featu
 import { InfoSection } from '@widgets/home/components/info-section/info-section.tsx';
 import { RecommendedInfoSection } from '@widgets/home/components/info-section/recommended-info-section.tsx';
 
+import { HOME_QUERY_OPTIONS } from '@shared/api/domain/home/queries.ts';
 import { routePath } from '@shared/router/path.ts';
 
 import * as styles from './home-page.css.ts';
@@ -15,11 +17,12 @@ import 'swiper/swiper-bundle.css';
 
 const HomePage = () => {
   const navigate = useNavigate();
-  const isRecommended = true;
 
   const handleNavigate = (path: string) => {
     navigate(path);
   };
+
+  const { data: userData } = useQuery(HOME_QUERY_OPTIONS.USER_INFO());
 
   return (
     <section className={styles.homePage}>
@@ -44,7 +47,11 @@ const HomePage = () => {
           />
         }
       />
-      {isRecommended ? <RecommendedInfoSection /> : <InfoSection />}
+      {userData?.isRecommendInsurance ? (
+        <RecommendedInfoSection userName={userData.username} />
+      ) : (
+        <InfoSection />
+      )}
       <FeaturesSection />
     </section>
   );

--- a/apps/client/src/shared/api/domain/home/queries.ts
+++ b/apps/client/src/shared/api/domain/home/queries.ts
@@ -2,8 +2,8 @@ import { queryOptions } from '@tanstack/react-query';
 
 import { END_POINT } from '@shared/api/config/end-point.ts';
 import { api } from '@shared/api/config/instance';
-import { HOME_QUERY_KEY } from '@shared/api/keys/query-key.ts';
-import { ReportSummaryRes } from '@shared/api/types/types';
+import { HOME_QUERY_KEY, USER_QUERY_KEY } from '@shared/api/keys/query-key.ts';
+import { ReportSummaryRes, UserProfile } from '@shared/api/types/types';
 
 export const HOME_QUERY_OPTIONS = {
   REPORT_SUMMARY: () => {
@@ -13,11 +13,25 @@ export const HOME_QUERY_OPTIONS = {
       select: (data: ReportSummaryRes | null) => data?.data,
     });
   },
+  USER_INFO: () => {
+    return queryOptions({
+      queryKey: USER_QUERY_KEY.PROFILE(),
+      queryFn: getUserProfile,
+      select: (data: UserProfile | null) => data?.data,
+    });
+  },
 };
 
 export const getReportSummary = async (): Promise<ReportSummaryRes | null> => {
   const response = await api
     .get(END_POINT.USER.GET_REPORT_SUMMARY)
     .json<ReportSummaryRes>();
+  return response;
+};
+
+export const getUserProfile = async (): Promise<UserProfile | null> => {
+  const response = await api
+    .get(END_POINT.USER.GET_USER_INFO)
+    .json<UserProfile>();
   return response;
 };

--- a/apps/client/src/shared/types/schema.d.ts
+++ b/apps/client/src/shared/types/schema.d.ts
@@ -614,14 +614,14 @@ export interface components {
       target?: string;
       status?: string;
     };
-    BaseResponseSliceResponseMyPostSummaryResponse: {
+    BaseResponseSliceResponseMyPostSummaryResponseLong: {
       /**
        * Format: int32
        * @example 200
        */
       code?: number;
       message?: string;
-      data?: components['schemas']['SliceResponseMyPostSummaryResponse'];
+      data?: components['schemas']['SliceResponseMyPostSummaryResponseLong'];
     };
     /** @description 데이터 목록 */
     MyPostSummaryResponse: {
@@ -651,26 +651,28 @@ export interface components {
        * @description 작성 시간
        */
       createdAt?: string;
+      /** Format: int64 */
+      cursor?: number;
     };
-    SliceResponseMyPostSummaryResponse: {
+    SliceResponseMyPostSummaryResponseLong: {
       /** @description 데이터 목록 */
       content?: components['schemas']['MyPostSummaryResponse'][];
       /**
        * Format: int64
-       * @description 다음 커서 ID
+       * @description 다음 커서
        */
       nextCursor?: number;
       /** @description 마지막 페이지 여부 */
       isLast?: boolean;
     };
-    BaseResponseSliceResponseMyCommentSummaryResponse: {
+    BaseResponseSliceResponseMyCommentSummaryResponseLong: {
       /**
        * Format: int32
        * @example 200
        */
       code?: number;
       message?: string;
-      data?: components['schemas']['SliceResponseMyCommentSummaryResponse'];
+      data?: components['schemas']['SliceResponseMyCommentSummaryResponseLong'];
     };
     /** @description 데이터 목록 */
     MyCommentSummaryResponse: {
@@ -694,13 +696,15 @@ export interface components {
        * @description 작성 시간
        */
       createdAt?: string;
+      /** Format: int64 */
+      cursor?: number;
     };
-    SliceResponseMyCommentSummaryResponse: {
+    SliceResponseMyCommentSummaryResponseLong: {
       /** @description 데이터 목록 */
       content?: components['schemas']['MyCommentSummaryResponse'][];
       /**
        * Format: int64
-       * @description 다음 커서 ID
+       * @description 다음 커서
        */
       nextCursor?: number;
       /** @description 마지막 페이지 여부 */
@@ -722,6 +726,11 @@ export interface components {
        * @example 1
        */
       userId?: number;
+      /**
+       * @description 이름
+       * @example 이정연
+       */
+      username?: string;
       /**
        * @description 유저 닉네임
        * @example 장정훈
@@ -811,14 +820,14 @@ export interface components {
     CoveragePreferenceResponses: {
       coveragePreferenceResponses?: components['schemas']['CoveragePreferenceResponse'][];
     };
-    BaseResponseSliceResponsePostSummaryResponse: {
+    BaseResponseSliceResponsePostSummaryResponseLong: {
       /**
        * Format: int32
        * @example 200
        */
       code?: number;
       message?: string;
-      data?: components['schemas']['SliceResponsePostSummaryResponse'];
+      data?: components['schemas']['SliceResponsePostSummaryResponseLong'];
     };
     /** @description 데이터 목록 */
     PostSummaryResponse: {
@@ -860,13 +869,15 @@ export interface components {
        * @description 게시물 작성 시각
        */
       createdAt?: string;
+      /** Format: int64 */
+      cursor?: number;
     };
-    SliceResponsePostSummaryResponse: {
+    SliceResponsePostSummaryResponseLong: {
       /** @description 데이터 목록 */
       content?: components['schemas']['PostSummaryResponse'][];
       /**
        * Format: int64
-       * @description 다음 커서 ID
+       * @description 다음 커서
        */
       nextCursor?: number;
       /** @description 마지막 페이지 여부 */
@@ -910,14 +921,14 @@ export interface components {
        */
       createdAt?: string;
     };
-    BaseResponseSliceResponseCommentResponse: {
+    BaseResponseSliceResponseCommentResponseLong: {
       /**
        * Format: int32
        * @example 200
        */
       code?: number;
       message?: string;
-      data?: components['schemas']['SliceResponseCommentResponse'];
+      data?: components['schemas']['SliceResponseCommentResponseLong'];
     };
     /** @description 데이터 목록 */
     CommentResponse: {
@@ -947,13 +958,15 @@ export interface components {
        * @description 수정 시간
        */
       updatedAt?: string;
+      /** Format: int64 */
+      cursor?: number;
     };
-    SliceResponseCommentResponse: {
+    SliceResponseCommentResponseLong: {
       /** @description 데이터 목록 */
       content?: components['schemas']['CommentResponse'][];
       /**
        * Format: int64
-       * @description 다음 커서 ID
+       * @description 다음 커서
        */
       nextCursor?: number;
       /** @description 마지막 페이지 여부 */
@@ -1358,7 +1371,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          '*/*': components['schemas']['BaseResponseSliceResponsePostSummaryResponse'];
+          '*/*': components['schemas']['BaseResponseSliceResponsePostSummaryResponseLong'];
         };
       };
       /** @description 경로 변수 값이 누락되었습니다. */
@@ -1370,7 +1383,7 @@ export interface operations {
           'application/json': unknown;
         };
       };
-      /** @description 유효하지 않은 JWT입니다. */
+      /** @description JWT 이 존재하지 않습니다. */
       401: {
         headers: {
           [name: string]: unknown;
@@ -1509,7 +1522,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          '*/*': components['schemas']['BaseResponseSliceResponseCommentResponse'];
+          '*/*': components['schemas']['BaseResponseSliceResponseCommentResponseLong'];
         };
       };
       400: {
@@ -1870,7 +1883,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          '*/*': components['schemas']['BaseResponseSliceResponseMyPostSummaryResponse'];
+          '*/*': components['schemas']['BaseResponseSliceResponseMyPostSummaryResponseLong'];
         };
       };
       400: {
@@ -1941,7 +1954,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          '*/*': components['schemas']['BaseResponseSliceResponseMyCommentSummaryResponse'];
+          '*/*': components['schemas']['BaseResponseSliceResponseMyCommentSummaryResponseLong'];
         };
       };
       400: {
@@ -2089,7 +2102,7 @@ export interface operations {
           'application/json': unknown;
         };
       };
-      /** @description 유효하지 않은 JWT입니다. */
+      /** @description JWT 이 존재하지 않습니다. */
       401: {
         headers: {
           [name: string]: unknown;
@@ -2163,7 +2176,7 @@ export interface operations {
           'application/json': unknown;
         };
       };
-      /** @description 유효하지 않은 JWT입니다. */
+      /** @description JWT 이 존재하지 않습니다. */
       401: {
         headers: {
           [name: string]: unknown;
@@ -2237,7 +2250,7 @@ export interface operations {
           'application/json': unknown;
         };
       };
-      /** @description 유효하지 않은 JWT입니다. */
+      /** @description JWT 이 존재하지 않습니다. */
       401: {
         headers: {
           [name: string]: unknown;

--- a/apps/client/src/widgets/home/components/info-section/recommended-info-section.tsx
+++ b/apps/client/src/widgets/home/components/info-section/recommended-info-section.tsx
@@ -20,8 +20,14 @@ import { routePath } from '@shared/router/path.ts';
 
 import * as styles from './recommended-info-section.css.ts';
 
+interface recommendedInfoSectionProps {
+  userName?: string;
+}
+
 /** 보험 추천받은 유저가 볼 화면 */
-export const RecommendedInfoSection = () => {
+export const RecommendedInfoSection = ({
+  userName,
+}: recommendedInfoSectionProps) => {
   const navigate = useNavigate();
   const handleNavigateReport = () => {
     navigate(routePath.REPORT);
@@ -61,7 +67,7 @@ export const RecommendedInfoSection = () => {
       />
       <div className={styles.titleSection}>
         <InsuranceSubtitle
-          name={'민정'}
+          name={userName ? userName : '고객님'}
           type={'home'}
           fontColor={'primary100'}
           fontStyle={'sb_14'}


### PR DESCRIPTION
## 📌 Summary

> - #209

 home 페이지 user Info api 연동 했습니다. 

## 📚 Tasks

1. user 정보 중에 isRecommendInsurance 가 true 일 때만 보험 추천 페이지를 보여주도록 했습니다. 
2. 만약 isRecommendInsurance 이 false 이면 보험, 어디서부터 시작해야
할지 막막하다면? 페이지가 뜹니다. 
3. 그리고 userName 을 RecommendedInfoSection props 를 뚫어 안에서 렌더링 되도록 구현했습니다. 

## 📸 Screenshot

<img width="538" height="835" alt="스크린샷 2025-07-17 02 42 46" src="https://github.com/user-attachments/assets/fbe7052c-0dca-4d82-9d61-ee4b87bc718d" />
<img width="565" height="830" alt="스크린샷 2025-07-17 02 42 36" src="https://github.com/user-attachments/assets/a60513ab-0e18-41de-bf76-4670da2b3451" />
