### PR TITLE
Feat(client): 보험 추천 리포트 수술 api 연동

### DIFF
--- a/apps/client/src/shared/api/config/end-point.ts
+++ b/apps/client/src/shared/api/config/end-point.ts
@@ -17,5 +17,6 @@ export const END_POINT = {
     GET_REPORT_SUMMARY: 'users/me/report-summary',
     GET_KEUNBYEONG_REPORT: (id: string) =>
       `insurances/reports/${id}/major-disease`,
+    GET_SUSUL_REPORT: (id: string) => `insurances/reports/${id}/surgery`,
   },
 };

--- a/apps/client/src/shared/api/domain/report/queries.ts
+++ b/apps/client/src/shared/api/domain/report/queries.ts
@@ -10,6 +10,7 @@ import {
   InsuranceKeunbyeongReport,
   InsuranceReport,
   InsuranceSummary,
+  InsuranceSusulReport,
   UserProfile,
 } from '@shared/api/types/types';
 
@@ -29,8 +30,14 @@ export const INSURANCE_QUERY_OPTIONS = {
   },
   REPORT_KEUNBYEONG: (reportId: string, section: string) => {
     return queryOptions({
-      queryKey: INSURANCE_QUERY_KEY.REPORT_KEUNBYEONG(reportId, section),
+      queryKey: INSURANCE_QUERY_KEY.REPORT_SECION(reportId, section),
       queryFn: () => getInsuranceKeunbyeongReport(reportId, section),
+    });
+  },
+  REPORT_SUSUL: (reportId: string, section: string) => {
+    return queryOptions({
+      queryKey: INSURANCE_QUERY_KEY.REPORT_SECION(reportId, section),
+      queryFn: () => getInsuranceSusulReport(reportId, section),
     });
   },
 };
@@ -70,6 +77,18 @@ export const getInsuranceKeunbyeongReport = async (
       searchParams: { section },
     })
     .json<InsuranceKeunbyeongReport>();
+  return response;
+};
+
+export const getInsuranceSusulReport = async (
+  reportId: string,
+  section: string,
+): Promise<InsuranceSusulReport | null> => {
+  const response = await api
+    .get(END_POINT.INSURANCE.GET_SUSUL_REPORT(reportId), {
+      searchParams: { section },
+    })
+    .json<InsuranceSusulReport>();
   return response;
 };
 

--- a/apps/client/src/shared/api/keys/query-key.ts
+++ b/apps/client/src/shared/api/keys/query-key.ts
@@ -2,7 +2,7 @@ export const INSURANCE_QUERY_KEY = {
   ALL: ['insurances'],
   REPORT: () => [...INSURANCE_QUERY_KEY.ALL, 'report'],
   REPORT_SUMMARY: () => [...INSURANCE_QUERY_KEY.ALL, 'report_summary'],
-  REPORT_KEUNBYEONG: (reportId: string, section: string) => [
+  REPORT_SECION: (reportId: string, section: string) => [
     ...INSURANCE_QUERY_KEY.ALL,
     reportId,
     section,

--- a/apps/client/src/shared/api/types/types.ts
+++ b/apps/client/src/shared/api/types/types.ts
@@ -26,6 +26,9 @@ export type InsuranceSummary =
 export type InsuranceKeunbyeongReport =
   paths['/insurances/reports/{insurance-report-id}/major-disease']['get']['responses']['200']['content']['*/*'];
 
+export type InsuranceSusulReport =
+  paths['/insurances/reports/{insurance-report-id}/surgery']['get']['responses']['200']['content']['*/*'];
+
 // COMMUNITY
 export type FeedResponse =
   paths['/posts']['post']['responses']['200']['content'];

--- a/apps/client/src/widgets/report/components/keunbyeong/components/cancer.tsx
+++ b/apps/client/src/widgets/report/components/keunbyeong/components/cancer.tsx
@@ -1,5 +1,6 @@
 import { Alert } from '@bds/ui';
 
+import { ACCORDION_CATEGORY } from '@widgets/report/constant/accordion-category-constant';
 import { ALERT } from '@widgets/report/constant/alert-content';
 
 import { InsuranceKeunbyeongReport } from '@shared/api/types/types';
@@ -22,12 +23,13 @@ interface CancerProps {
 
 const Cancer = ({ onClick, data, target, status }: CancerProps) => {
   const hasCoverage = useCoverage({ sections: data?.sections });
+
   return (
     <Accordion>
       <Accordion.Header
         type={status}
         onClick={onClick}
-        accordionCategory="cancer"
+        accordionCategory={ACCORDION_CATEGORY.KEUNBYEONG.CANCER}
       >
         {target}
       </Accordion.Header>

--- a/apps/client/src/widgets/report/components/keunbyeong/components/noehyeolgwan.tsx
+++ b/apps/client/src/widgets/report/components/keunbyeong/components/noehyeolgwan.tsx
@@ -1,5 +1,6 @@
 import { Alert } from '@bds/ui';
 
+import { ACCORDION_CATEGORY } from '@widgets/report/constant/accordion-category-constant';
 import { ALERT } from '@widgets/report/constant/alert-content';
 
 import { InsuranceKeunbyeongReport } from '@shared/api/types/types';
@@ -28,7 +29,7 @@ const Noehyeolgwan = ({ onClick, data, target, status }: NoehyeolgwanProps) => {
       <Accordion.Header
         type={status}
         onClick={onClick}
-        accordionCategory="cerebrovascular"
+        accordionCategory={ACCORDION_CATEGORY.KEUNBYEONG.NOEHYEOLGWAN}
       >
         {target}
       </Accordion.Header>

--- a/apps/client/src/widgets/report/components/keunbyeong/components/shimjang.tsx
+++ b/apps/client/src/widgets/report/components/keunbyeong/components/shimjang.tsx
@@ -1,5 +1,6 @@
 import { Alert } from '@bds/ui';
 
+import { ACCORDION_CATEGORY } from '@widgets/report/constant/accordion-category-constant';
 import { ALERT } from '@widgets/report/constant/alert-content';
 
 import { InsuranceKeunbyeongReport } from '@shared/api/types/types';
@@ -28,7 +29,7 @@ const Shimjang = ({ onClick, data, target, status }: ShimjangProps) => {
       <Accordion.Header
         type={status}
         onClick={onClick}
-        accordionCategory="heart-disease"
+        accordionCategory={ACCORDION_CATEGORY.KEUNBYEONG.SHIMJANG}
       >
         {target}
       </Accordion.Header>

--- a/apps/client/src/widgets/report/components/susul/components/jilbyeong-class.tsx
+++ b/apps/client/src/widgets/report/components/susul/components/jilbyeong-class.tsx
@@ -1,49 +1,38 @@
+import { ACCORDION_CATEGORY } from '@widgets/report/constant/accordion-category-constant';
+
+import { InsuranceSusulReport } from '@shared/api/types/types';
 import { StatusType } from '@shared/types/type';
 
 import { Accordion } from '../../accordion/accordion';
 import Class from '../../class/class';
 
 interface JilbyeongProps {
+  onClick: (category: string) => void;
+  data: InsuranceSusulReport['data'];
   target?: string;
   status?: StatusType;
 }
 
-//mock 데이터
-const jilbyeongClassData = {
-  surgeryType: {
-    type1: {
-      productCoverage: 10,
-      averageCoverage: 20,
-    },
-    type2: {
-      productCoverage: 25,
-      averageCoverage: 30,
-    },
-    type3: {
-      productCoverage: 120,
-      averageCoverage: 100,
-    },
-    type4: {
-      productCoverage: 250,
-      averageCoverage: 500,
-    },
-    type5: {
-      productCoverage: 1200,
-      averageCoverage: 1000,
-    },
-  },
-};
+const JilbyeongClass = ({ onClick, data, target, status }: JilbyeongProps) => {
+  const surgeryList = Object.values(data?.surgeryType ?? {});
 
-const JilbyeongClass = ({ target, status }: JilbyeongProps) => {
-  const surgeryList = Object.values(jilbyeongClassData.surgeryType);
-
-  const averageValues = surgeryList.map((surgery) => surgery.averageCoverage);
-  const guaranteeValues = surgeryList.map((surgery) => surgery.productCoverage);
+  const averageValues = surgeryList.map(
+    (surgery) => surgery.averageCoverage ?? 0,
+  );
+  const guaranteeValues = surgeryList.map(
+    (surgery) => surgery.productCoverage ?? 0,
+  );
 
   return (
     <div>
       <Accordion>
-        <Accordion.Header type={status}>{target}</Accordion.Header>
+        <Accordion.Header
+          type={status}
+          onClick={onClick}
+          accordionCategory={ACCORDION_CATEGORY.SUSUL.JILBYEONG_CLASS}
+        >
+          {target}
+        </Accordion.Header>
         <Accordion.Panel>
           <Class
             averageValues={averageValues}

--- a/apps/client/src/widgets/report/components/susul/components/jilbyeong.tsx
+++ b/apps/client/src/widgets/report/components/susul/components/jilbyeong.tsx
@@ -1,33 +1,36 @@
 import { Alert } from '@bds/ui';
 
+import { ACCORDION_CATEGORY } from '@widgets/report/constant/accordion-category-constant';
 import { ALERT } from '@widgets/report/constant/alert-content';
 
+import { InsuranceSusulReport } from '@shared/api/types/types';
 import { StatusType } from '@shared/types/type';
 
 import { Accordion } from '../../accordion/accordion';
 import Graph from '../../graph/graph';
 
 interface JilbyeongClassProps {
+  onClick: (category: string) => void;
+  data: InsuranceSusulReport['data'];
   target?: string;
   status?: StatusType;
 }
 
-//mock 데이터
-const jilbyeongData = {
-  surgery: {
-    productCoverage: 0,
-    averageCoverage: 50,
-  },
-};
+const Jilbyeong = ({ target, status, onClick, data }: JilbyeongClassProps) => {
+  const hasCoverage = data?.surgery?.productCoverage == 0;
 
-const Jilbyeong = ({ target, status }: JilbyeongClassProps) => {
-  const isZero = jilbyeongData.surgery.productCoverage == 0;
   return (
     <>
       <Accordion>
-        <Accordion.Header type={status}>{target}</Accordion.Header>
+        <Accordion.Header
+          type={status}
+          onClick={onClick}
+          accordionCategory={ACCORDION_CATEGORY.SUSUL.JILBYEONG}
+        >
+          {target}
+        </Accordion.Header>
         <Accordion.Panel>
-          {isZero ? (
+          {hasCoverage ? (
             <Alert
               type="additional"
               iconName="info_warning"
@@ -38,8 +41,8 @@ const Jilbyeong = ({ target, status }: JilbyeongClassProps) => {
             />
           ) : (
             <Graph
-              average={jilbyeongData.surgery.averageCoverage}
-              current={jilbyeongData.surgery.productCoverage}
+              average={data?.surgery?.averageCoverage}
+              current={data?.surgery?.productCoverage}
             />
           )}
         </Accordion.Panel>

--- a/apps/client/src/widgets/report/components/susul/components/sanghae-class.tsx
+++ b/apps/client/src/widgets/report/components/susul/components/sanghae-class.tsx
@@ -1,49 +1,38 @@
+import { ACCORDION_CATEGORY } from '@widgets/report/constant/accordion-category-constant';
+
+import { InsuranceSusulReport } from '@shared/api/types/types';
 import { StatusType } from '@shared/types/type';
 
 import { Accordion } from '../../accordion/accordion';
 import Class from '../../class/class';
 
 interface SanghaeProps {
+  onClick: (category: string) => void;
+  data: InsuranceSusulReport['data'];
   target?: string;
   status?: StatusType;
 }
 
-//mock 데이터
-const sanghaeClassdata = {
-  surgeryType: {
-    type1: {
-      productCoverage: 10,
-      averageCoverage: 20,
-    },
-    type2: {
-      productCoverage: 15,
-      averageCoverage: 30,
-    },
-    type3: {
-      productCoverage: 10,
-      averageCoverage: 100,
-    },
-    type4: {
-      productCoverage: 10,
-      averageCoverage: 500,
-    },
-    type5: {
-      productCoverage: 10,
-      averageCoverage: 1000,
-    },
-  },
-};
+const SanghaeClass = ({ target, status, onClick, data }: SanghaeProps) => {
+  const surgeryList = Object.values(data?.surgeryType ?? {});
 
-const SanghaeClass = ({ target, status }: SanghaeProps) => {
-  const surgeryList = Object.values(sanghaeClassdata.surgeryType);
-
-  const averageValues = surgeryList.map((surgery) => surgery.averageCoverage);
-  const guaranteeValues = surgeryList.map((surgery) => surgery.productCoverage);
+  const averageValues = surgeryList.map(
+    (surgery) => surgery.averageCoverage ?? 0,
+  );
+  const guaranteeValues = surgeryList.map(
+    (surgery) => surgery.productCoverage ?? 0,
+  );
 
   return (
     <div>
       <Accordion>
-        <Accordion.Header type={status}>{target}</Accordion.Header>
+        <Accordion.Header
+          type={status}
+          onClick={onClick}
+          accordionCategory={ACCORDION_CATEGORY.SUSUL.SANGHAE_CLASS}
+        >
+          {target}
+        </Accordion.Header>
         <Accordion.Panel>
           <Class
             averageValues={averageValues}

--- a/apps/client/src/widgets/report/components/susul/components/sanghae.tsx
+++ b/apps/client/src/widgets/report/components/susul/components/sanghae.tsx
@@ -1,31 +1,33 @@
 import { Alert } from '@bds/ui';
 
+import { ACCORDION_CATEGORY } from '@widgets/report/constant/accordion-category-constant';
 import { ALERT } from '@widgets/report/constant/alert-content';
 
+import { InsuranceSusulReport } from '@shared/api/types/types';
 import { StatusType } from '@shared/types/type';
 
 import { Accordion } from '../../accordion/accordion';
 import Graph from '../../graph/graph';
 
 interface SanghaeClassProps {
+  onClick: (category: string) => void;
+  data: InsuranceSusulReport['data'];
   target?: string;
   status?: StatusType;
 }
 
-//mock 데이터
-const sanghaeData = {
-  surgery: {
-    productCoverage: 60,
-    averageCoverage: 50,
-  },
-};
-
-const Sanghae = ({ target, status }: SanghaeClassProps) => {
-  const hasCoverage = sanghaeData.surgery.productCoverage == 0;
+const Sanghae = ({ target, status, data, onClick }: SanghaeClassProps) => {
+  const hasCoverage = data?.surgery?.productCoverage == 0;
   return (
     <div>
       <Accordion>
-        <Accordion.Header type={status}>{target}</Accordion.Header>
+        <Accordion.Header
+          type={status}
+          onClick={onClick}
+          accordionCategory={ACCORDION_CATEGORY.SUSUL.SANGHEA}
+        >
+          {target}
+        </Accordion.Header>
         <Accordion.Panel>
           {hasCoverage ? (
             <Alert
@@ -38,8 +40,8 @@ const Sanghae = ({ target, status }: SanghaeClassProps) => {
             />
           ) : (
             <Graph
-              average={sanghaeData.surgery.averageCoverage}
-              current={sanghaeData.surgery.productCoverage}
+              average={data?.surgery?.averageCoverage}
+              current={data?.surgery?.productCoverage}
             />
           )}
         </Accordion.Panel>

--- a/apps/client/src/widgets/report/components/susul/susul.tsx
+++ b/apps/client/src/widgets/report/components/susul/susul.tsx
@@ -1,3 +1,7 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { INSURANCE_QUERY_OPTIONS } from '@shared/api/domain/report/queries';
 import { components } from '@shared/types/schema';
 import { StatusType } from '@shared/types/type';
 
@@ -15,6 +19,7 @@ interface SusulProps {
 }
 
 const TEXT_TITLE = '수술';
+const TEST_REPORT_ID = '2281ccfc-1f10-4798-b3ad-6468b357b789';
 
 const COMPONENT = [
   { Component: Jilbyeong },
@@ -24,6 +29,17 @@ const COMPONENT = [
 ] as const;
 
 const Susul = ({ sectionData }: SusulProps) => {
+  const [accordionCategory, setAccordionCategory] = useState('');
+
+  const handleSelectClick = (category: string) => {
+    setAccordionCategory(category);
+  };
+
+  const { data: susulData } = useQuery({
+    ...INSURANCE_QUERY_OPTIONS.REPORT_SUSUL(TEST_REPORT_ID, accordionCategory),
+    enabled: !!accordionCategory,
+  });
+
   return (
     <div className={styles.container}>
       <Divider>{TEXT_TITLE}</Divider>
@@ -38,7 +54,12 @@ const Susul = ({ sectionData }: SusulProps) => {
         {sectionData?.statuses?.map(({ target, status }, index) => {
           const Component = COMPONENT[index]?.Component;
           return Component ? (
-            <Component target={target} status={status as StatusType} />
+            <Component
+              target={target}
+              status={status as StatusType}
+              onClick={handleSelectClick}
+              data={susulData?.data}
+            />
           ) : null;
         })}
       </div>

--- a/apps/client/src/widgets/report/constant/accordion-category-constant.ts
+++ b/apps/client/src/widgets/report/constant/accordion-category-constant.ts
@@ -1,0 +1,25 @@
+export const ACCORDION_CATEGORY = {
+  KEUNBYEONG: {
+    CANCER: 'cancer',
+    NOEHYEOLGWAN: 'cerebrovascular',
+    SHIMJANG: 'heart-disease',
+  },
+  SUSUL: {
+    JILBYEONG: 'disease-surgery',
+    JILBYEONG_CLASS: 'disease-type-surgery',
+    SANGHEA: 'injury-surgery',
+    SANGHAE_CLASS: 'injury-type-surgery',
+  },
+  IPWON: {
+    JILBYEONG: 'disease-daily-hospitalization',
+    SANGHAE: 'injury-daily-hospitalization',
+  },
+  JANGHAE: {
+    JILBYEONG: 'disease-disability',
+    SANGHAE: 'injury-disability',
+  },
+  SAMANG: {
+    JILBYEONG: 'disease-death',
+    SANGHAE: 'injury-death',
+  },
+};


### PR DESCRIPTION
## 📌 Summary

- close #236 

보험 추천 리포트 수술 api를 연동합니다. 

## 📚 Tasks

아코디언의 화살표 버튼을 클릭했을 시 파라미터를 전송 해 클릭했을 시에만 get 요청을 보내는 작업을 수행하였습니다 !!

## 👀 To Reviewer

```tsx
export const INSURANCE_QUERY_KEY = {
  ALL: ['insurances'],
  REPORT: () => [...INSURANCE_QUERY_KEY.ALL, 'report'],
  REPORT_SUMMARY: () => [...INSURANCE_QUERY_KEY.ALL, 'report_summary'],
  REPORT_KEUNBYEONG: (reportId: string, section: string) => [
    ...INSURANCE_QUERY_KEY.ALL,
    reportId,
    section,
  ],
REPORT_SUSUL: (reportId: string, section: string) => [
   ...INSURANCE_QUERY_KEY.ALL, 
   reportId, 
   section,
 ],
} as const;
```


이런 구조로 query key를 가지고 가려고 했으나,
구조가 똑같고, section(파라미터로 넘겨질 값)의 값이 string으로 'cancer, 'disease-...' 이런식으로 넘어가서 고유 키 값을 가질 수 있다는 의견 하에 아래와 같이 REPORT_SECTION이라는 공통 구조로 가지고 가기로 결정하였습니다.


```tsx
export const INSURANCE_QUERY_KEY = {
  ALL: ['insurances'],
  REPORT: () => [...INSURANCE_QUERY_KEY.ALL, 'report'],
  REPORT_SUMMARY: () => [...INSURANCE_QUERY_KEY.ALL, 'report_summary'],
  REPORT_SECION: (reportId: string, section: string) => [
    ...INSURANCE_QUERY_KEY.ALL,
    reportId,
    section,
  ],
} as const;
```


<!--
## 🕶️ Requirements Checklist
- [ ]

(기능 명세서상 내용을 복사해서 테스트해주세요)
-->


## 📸 Screenshot

<img width="690" height="377" alt="image" src="https://github.com/user-attachments/assets/6b7b5ef7-34ae-45aa-9b5d-b248b6b51fa9" />


