### PR TITLE
Feat(client): 보험 추천 리포트 입원 api 연동

### DIFF
--- a/apps/client/src/shared/api/config/end-point.ts
+++ b/apps/client/src/shared/api/config/end-point.ts
@@ -21,5 +21,7 @@ export const END_POINT = {
     GET_KEUNBYEONG_REPORT: (id: string) =>
       `insurances/reports/${id}/major-disease`,
     GET_SUSUL_REPORT: (id: string) => `insurances/reports/${id}/surgery`,
+    GET_IPWON_REPORT: (id: string) =>
+      `insurances/reports/${id}/hospitalization`,
   },
 };

--- a/apps/client/src/shared/api/domain/report/queries.ts
+++ b/apps/client/src/shared/api/domain/report/queries.ts
@@ -7,6 +7,7 @@ import {
   USER_QUERY_KEY,
 } from '@shared/api/keys/query-key';
 import {
+  InsuranceIpwonReport,
   InsuranceKeunbyeongReport,
   InsuranceReport,
   InsuranceSummary,
@@ -38,6 +39,12 @@ export const INSURANCE_QUERY_OPTIONS = {
     return queryOptions({
       queryKey: INSURANCE_QUERY_KEY.REPORT_SECION(reportId, section),
       queryFn: () => getInsuranceSusulReport(reportId, section),
+    });
+  },
+  REPORT_IPWON: (reportId: string, section: string) => {
+    return queryOptions({
+      queryKey: INSURANCE_QUERY_KEY.REPORT_SECION(reportId, section),
+      queryFn: () => getInsuranceIpwonReport(reportId, section),
     });
   },
 };
@@ -89,6 +96,18 @@ export const getInsuranceSusulReport = async (
       searchParams: { section },
     })
     .json<InsuranceSusulReport>();
+  return response;
+};
+
+export const getInsuranceIpwonReport = async (
+  reportId: string,
+  section: string,
+): Promise<InsuranceIpwonReport | null> => {
+  const response = await api
+    .get(END_POINT.INSURANCE.GET_IPWON_REPORT(reportId), {
+      searchParams: { section },
+    })
+    .json<InsuranceIpwonReport>();
   return response;
 };
 

--- a/apps/client/src/shared/api/types/types.ts
+++ b/apps/client/src/shared/api/types/types.ts
@@ -35,6 +35,9 @@ export type InsuranceKeunbyeongReport =
 export type InsuranceSusulReport =
   paths['/insurances/reports/{insurance-report-id}/surgery']['get']['responses']['200']['content']['*/*'];
 
+export type InsuranceIpwonReport =
+  paths['/insurances/reports/{insurance-report-id}/hospitalization']['get']['responses']['200']['content']['*/*'];
+
 // COMMUNITY
 export type FeedResponse =
   paths['/posts']['post']['responses']['200']['content'];

--- a/apps/client/src/widgets/report/components/ipwon/components/jilbyeong.tsx
+++ b/apps/client/src/widgets/report/components/ipwon/components/jilbyeong.tsx
@@ -1,30 +1,32 @@
 import { Alert } from '@bds/ui';
 
+import { ACCORDION_CATEGORY } from '@widgets/report/constant/accordion-category-constant';
 import { ALERT } from '@widgets/report/constant/alert-content';
 
+import { InsuranceIpwonReport } from '@shared/api/types/types';
 import { StatusType } from '@shared/types/type';
 
 import { Accordion } from '../../accordion/accordion';
 import Graph from '../../graph/graph';
 
 interface JilbyeongProps {
+  onClick: (category: string) => void;
+  data: InsuranceIpwonReport['data'];
   target?: string;
   status?: StatusType;
 }
 
-//mock 데이터
-const jilbyeongData = {
-  surgery: {
-    productCoverage: 1000,
-    averageCoverage: 500,
-  },
-};
-
-const Jilbyeong = ({ target, status }: JilbyeongProps) => {
-  const hasCoverage = jilbyeongData.surgery.productCoverage == 0;
+const Jilbyeong = ({ target, status, onClick, data }: JilbyeongProps) => {
+  const hasCoverage = data?.diseaseDailyHospitalization?.productCoverage == 0;
   return (
     <Accordion>
-      <Accordion.Header type={status}>{target}</Accordion.Header>
+      <Accordion.Header
+        type={status}
+        onClick={onClick}
+        accordionCategory={ACCORDION_CATEGORY.IPWON.JILBYEONG}
+      >
+        {target}
+      </Accordion.Header>
       <Accordion.Panel>
         {hasCoverage ? (
           <Alert
@@ -37,8 +39,8 @@ const Jilbyeong = ({ target, status }: JilbyeongProps) => {
           />
         ) : (
           <Graph
-            average={jilbyeongData.surgery.averageCoverage}
-            current={jilbyeongData.surgery.productCoverage}
+            average={data?.diseaseDailyHospitalization?.averageCoverage}
+            current={data?.diseaseDailyHospitalization?.productCoverage}
           />
         )}
       </Accordion.Panel>

--- a/apps/client/src/widgets/report/components/ipwon/components/sanghae.tsx
+++ b/apps/client/src/widgets/report/components/ipwon/components/sanghae.tsx
@@ -1,30 +1,32 @@
 import { Alert } from '@bds/ui';
 
+import { ACCORDION_CATEGORY } from '@widgets/report/constant/accordion-category-constant';
 import { ALERT } from '@widgets/report/constant/alert-content';
 
+import { InsuranceIpwonReport } from '@shared/api/types/types';
 import { StatusType } from '@shared/types/type';
 
 import { Accordion } from '../../accordion/accordion';
 import Graph from '../../graph/graph';
 
 interface SanghaeProps {
+  onClick: (category: string) => void;
+  data: InsuranceIpwonReport['data'];
   target?: string;
   status?: StatusType;
 }
 
-//mock 데이터
-const janghaeData = {
-  surgery: {
-    productCoverage: 30,
-    averageCoverage: 50,
-  },
-};
-
-const Sanghae = ({ target, status }: SanghaeProps) => {
-  const hasCoverage = janghaeData.surgery.productCoverage == 0;
+const Sanghae = ({ target, status, onClick, data }: SanghaeProps) => {
+  const hasCoverage = data?.diseaseDailyHospitalization?.productCoverage == 0;
   return (
     <Accordion>
-      <Accordion.Header type={status}>{target}</Accordion.Header>
+      <Accordion.Header
+        type={status}
+        onClick={onClick}
+        accordionCategory={ACCORDION_CATEGORY.IPWON.SANGHAE}
+      >
+        {target}
+      </Accordion.Header>
       <Accordion.Panel>
         {hasCoverage ? (
           <Alert
@@ -37,8 +39,8 @@ const Sanghae = ({ target, status }: SanghaeProps) => {
           />
         ) : (
           <Graph
-            average={janghaeData.surgery.averageCoverage}
-            current={janghaeData.surgery.productCoverage}
+            average={data?.diseaseDailyHospitalization?.averageCoverage}
+            current={data?.diseaseDailyHospitalization?.productCoverage}
           />
         )}
       </Accordion.Panel>

--- a/apps/client/src/widgets/report/components/ipwon/ipwon.tsx
+++ b/apps/client/src/widgets/report/components/ipwon/ipwon.tsx
@@ -1,3 +1,10 @@
+import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { ACCORDION_CATEGORY } from '@widgets/report/constant/accordion-category-constant';
+
+import { INSURANCE_QUERY_OPTIONS } from '@shared/api/domain/report/queries';
+import { InsuranceIpwonReport } from '@shared/api/types/types';
 import { components } from '@shared/types/schema';
 import { StatusType } from '@shared/types/type';
 
@@ -13,10 +20,37 @@ interface IpwonProps {
 }
 
 const TEXT_TITLE = '입원';
+const TEST_REPORT_ID = '2281ccfc-1f10-4798-b3ad-6468b357b789';
 
-const COMPONENT = [{ Component: Jilbyeong }, { Component: Sanghae }] as const;
+const IPWON_COMPONENT = [
+  { Component: Jilbyeong, key: ACCORDION_CATEGORY.IPWON.JILBYEONG },
+  { Component: Sanghae, key: ACCORDION_CATEGORY.IPWON.SANGHAE },
+] as const;
 
 const Ipwon = ({ sectionData }: IpwonProps) => {
+  const [cachedDataMap, setCachedDataMap] = useState<
+    Partial<Record<string, InsuranceIpwonReport['data']>>
+  >({});
+  const [accordionCategory, setAccordionCategory] = useState('');
+
+  const handleSelectClick = (category: string) => {
+    setAccordionCategory(category);
+  };
+
+  const { data: ipwonData } = useQuery({
+    ...INSURANCE_QUERY_OPTIONS.REPORT_IPWON(TEST_REPORT_ID, accordionCategory),
+    enabled: !!accordionCategory && !cachedDataMap[accordionCategory],
+  });
+
+  useEffect(() => {
+    if (ipwonData?.data?.hyphenCase) {
+      setCachedDataMap((prev) => ({
+        ...prev,
+        [ipwonData?.data?.hyphenCase ?? '']: ipwonData.data,
+      }));
+    }
+  }, [ipwonData]);
+
   return (
     <div className={styles.container}>
       <Divider>{TEXT_TITLE}</Divider>
@@ -26,12 +60,15 @@ const Ipwon = ({ sectionData }: IpwonProps) => {
           size="md"
           iconSize="2rem"
         />
-        {sectionData?.statuses?.map(({ target, status }, index) => {
-          const Component = COMPONENT[index]?.Component;
-          return Component ? (
-            <Component target={target} status={status as StatusType} />
-          ) : null;
-        })}
+        {IPWON_COMPONENT.map(({ Component, key }, index) => (
+          <Component
+            key={key}
+            target={sectionData?.statuses?.[index].target}
+            status={sectionData?.statuses?.[index].status as StatusType}
+            onClick={handleSelectClick}
+            data={cachedDataMap[key]}
+          />
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## 📌 Summary

- #252 

보험 추천 리포트 입원 api를 연동합니다.

## 📚 Tasks

아까와 동일한 보험 추천 리포트에서 아코디언 화살표 버튼을 클릭할 시 한번만 요청을 보내도록 구현하였습니다.

## 👀 To Reviewer
앞에서 올렸던 것과 같은 방식대로 api를 구현하였습니다.
나중에 pr 자세히 쓸게요.. 시간 없다

<!--
## 🕶️ Requirements Checklist
- [ ]

(기능 명세서상 내용을 복사해서 테스트해주세요)
-->

## 📸 Screenshot

https://github.com/user-attachments/assets/76ffb801-dccc-4996-a9ce-f0e60df616db



