### PR TITLE
[QA-1] 보험 추천 리포트 페이지 QA 반영

### DIFF
--- a/apps/client/src/widgets/report/components/accordion/accordion.css.ts
+++ b/apps/client/src/widgets/report/components/accordion/accordion.css.ts
@@ -15,6 +15,7 @@ export const accordionContainer = style({
 export const headerContainer = style({
   display: 'flex',
   gap: '1.2rem',
+  cursor: 'pointer',
 });
 
 export const headerContentsContainer = style({
@@ -27,7 +28,6 @@ export const headerContentsContainer = style({
 export const iconContainer = style({
   display: 'flex',
   alignItems: 'center',
-  cursor: 'pointer',
 });
 
 export const icon = style({

--- a/apps/client/src/widgets/report/components/accordion/accordion.tsx
+++ b/apps/client/src/widgets/report/components/accordion/accordion.tsx
@@ -54,12 +54,12 @@ export const AccordionHeader = ({
   };
 
   return (
-    <div className={styles.headerContainer}>
+    <div className={styles.headerContainer} onClick={handleAccordionClick}>
       <div className={styles.headerContentsContainer}>
         <Title category="mainCategory" title={children} />
         <Chip type={type} />
       </div>
-      <div className={styles.iconContainer} onClick={handleAccordionClick}>
+      <div className={styles.iconContainer}>
         <Icon
           className={styles.icon}
           name="caret_up_lg"

--- a/apps/client/src/widgets/report/components/ipwon/components/jilbyeong.tsx
+++ b/apps/client/src/widgets/report/components/ipwon/components/jilbyeong.tsx
@@ -35,7 +35,7 @@ const Jilbyeong = ({ target, status, onClick, data }: JilbyeongProps) => {
             iconName="info_warning"
             iconSize="2rem"
             alertHeader={ALERT.HEADER}
-            alertContents={ALERT.CONTENTS}
+            alertContents={ALERT.EUN_CONTENTS}
             highlight={target}
           />
         ) : (

--- a/apps/client/src/widgets/report/components/ipwon/components/sanghae.tsx
+++ b/apps/client/src/widgets/report/components/ipwon/components/sanghae.tsx
@@ -34,7 +34,7 @@ const Sanghae = ({ target, status, onClick, data }: SanghaeProps) => {
             iconName="info_warning"
             iconSize="2rem"
             alertHeader={ALERT.HEADER}
-            alertContents={ALERT.CONTENTS}
+            alertContents={ALERT.EUN_CONTENTS}
             highlight={target}
           />
         ) : (

--- a/apps/client/src/widgets/report/components/janghae/components/jilbyeong.tsx
+++ b/apps/client/src/widgets/report/components/janghae/components/jilbyeong.tsx
@@ -34,7 +34,7 @@ const Jilbyeong = ({ onClick, data, target, status }: JilbyeongProps) => {
             iconName="info_warning"
             iconSize="2rem"
             alertHeader={ALERT.HEADER}
-            alertContents={ALERT.CONTENTS}
+            alertContents={ALERT.NEUN_CONTENTS}
             highlight={target}
           />
         ) : (

--- a/apps/client/src/widgets/report/components/janghae/components/sanghae.tsx
+++ b/apps/client/src/widgets/report/components/janghae/components/sanghae.tsx
@@ -34,7 +34,7 @@ const Sanghae = ({ onClick, data, target, status }: SanghaeProps) => {
             iconName="info_warning"
             iconSize="2rem"
             alertHeader={ALERT.HEADER}
-            alertContents={ALERT.CONTENTS}
+            alertContents={ALERT.NEUN_CONTENTS}
             highlight={target}
           />
         ) : (

--- a/apps/client/src/widgets/report/components/keunbyeong/components/cancer.tsx
+++ b/apps/client/src/widgets/report/components/keunbyeong/components/cancer.tsx
@@ -50,7 +50,7 @@ const Cancer = ({ onClick, data, target, status }: CancerProps) => {
                       iconName="info_warning"
                       iconSize="2rem"
                       alertHeader={ALERT.HEADER}
-                      alertContents={ALERT.CONTENTS}
+                      alertContents={ALERT.EUN_CONTENTS}
                       highlight={displayName}
                     />
                   ) : (

--- a/apps/client/src/widgets/report/components/keunbyeong/components/noehyeolgwan.tsx
+++ b/apps/client/src/widgets/report/components/keunbyeong/components/noehyeolgwan.tsx
@@ -50,7 +50,7 @@ const Noehyeolgwan = ({ onClick, data, target, status }: NoehyeolgwanProps) => {
                       iconName="info_warning"
                       iconSize="2rem"
                       alertHeader={ALERT.HEADER}
-                      alertContents={ALERT.CONTENTS}
+                      alertContents={ALERT.EUN_CONTENTS}
                       highlight={displayName}
                     />
                   ) : (

--- a/apps/client/src/widgets/report/components/keunbyeong/components/shimjang.tsx
+++ b/apps/client/src/widgets/report/components/keunbyeong/components/shimjang.tsx
@@ -81,7 +81,7 @@ const Shimjang = ({ onClick, data, target, status }: ShimjangProps) => {
                             iconName="info_warning"
                             iconSize="2rem"
                             alertHeader={ALERT.HEADER}
-                            alertContents={ALERT.JINDAN_CONTENTS}
+                            alertContents={ALERT.SUSUL_CONTENTS}
                             highlight={displayName}
                           />
                         </div>

--- a/apps/client/src/widgets/report/components/keunbyeong/components/shimjang.tsx
+++ b/apps/client/src/widgets/report/components/keunbyeong/components/shimjang.tsx
@@ -50,7 +50,7 @@ const Shimjang = ({ onClick, data, target, status }: ShimjangProps) => {
                       iconName="info_warning"
                       iconSize="2rem"
                       alertHeader={ALERT.HEADER}
-                      alertContents={ALERT.CONTENTS}
+                      alertContents={ALERT.EUN_CONTENTS}
                       highlight={displayName}
                     />
                   ) : (

--- a/apps/client/src/widgets/report/components/report-detail/report-detail.tsx
+++ b/apps/client/src/widgets/report/components/report-detail/report-detail.tsx
@@ -25,7 +25,7 @@ const SECTIONS = [
 
 const TEXT = {
   BUTTON_TEXT: '더 자세한 보장 알아보기',
-  SUB_TEXT: '이 보험에 관심이 있다면',
+  SUB_TEXT: '이 보험에 관심이 있다면, ',
   HOME_TEXT: '홈으로',
 };
 

--- a/apps/client/src/widgets/report/components/samang/components/jilbyeong.tsx
+++ b/apps/client/src/widgets/report/components/samang/components/jilbyeong.tsx
@@ -35,7 +35,7 @@ const Jilbyeong = ({ target, status, onClick, data }: JilbyeongProps) => {
             iconName="info_warning"
             iconSize="2rem"
             alertHeader={ALERT.HEADER}
-            alertContents={ALERT.CONTENTS}
+            alertContents={ALERT.EUN_CONTENTS}
             highlight={target}
           />
         ) : (

--- a/apps/client/src/widgets/report/components/samang/components/sanghae.tsx
+++ b/apps/client/src/widgets/report/components/samang/components/sanghae.tsx
@@ -34,7 +34,7 @@ const Sanghae = ({ target, status, onClick, data }: SanghaeProps) => {
             iconName="info_warning"
             iconSize="2rem"
             alertHeader={ALERT.HEADER}
-            alertContents={ALERT.CONTENTS}
+            alertContents={ALERT.EUN_CONTENTS}
             highlight={target}
           />
         ) : (

--- a/apps/client/src/widgets/report/components/susul/components/jilbyeong-class.tsx
+++ b/apps/client/src/widgets/report/components/susul/components/jilbyeong-class.tsx
@@ -1,4 +1,7 @@
+import { Alert } from '@bds/ui';
+
 import { ACCORDION_CATEGORY } from '@widgets/report/constant/accordion-category-constant';
+import { ALERT } from '@widgets/report/constant/alert-content';
 
 import { InsuranceSusulReport } from '@shared/api/types/types';
 import { StatusType } from '@shared/types/type';
@@ -23,6 +26,8 @@ const JilbyeongClass = ({ onClick, data, target, status }: JilbyeongProps) => {
     (surgery) => surgery.productCoverage ?? 0,
   );
 
+  const hasCoverage = guaranteeValues.every((value) => value === 0);
+
   return (
     <div>
       <Accordion>
@@ -34,10 +39,21 @@ const JilbyeongClass = ({ onClick, data, target, status }: JilbyeongProps) => {
           {target}
         </Accordion.Header>
         <Accordion.Panel>
-          <Class
-            averageValues={averageValues}
-            guaranteeValues={guaranteeValues}
-          />
+          {hasCoverage ? (
+            <Alert
+              type="additional"
+              iconName="info_warning"
+              iconSize="2rem"
+              alertHeader={ALERT.HEADER}
+              alertContents={ALERT.NEUN_CONTENTS}
+              highlight={target}
+            />
+          ) : (
+            <Class
+              averageValues={averageValues}
+              guaranteeValues={guaranteeValues}
+            />
+          )}
         </Accordion.Panel>
       </Accordion>
     </div>

--- a/apps/client/src/widgets/report/components/susul/components/jilbyeong.tsx
+++ b/apps/client/src/widgets/report/components/susul/components/jilbyeong.tsx
@@ -36,7 +36,7 @@ const Jilbyeong = ({ target, status, onClick, data }: JilbyeongClassProps) => {
               iconName="info_warning"
               iconSize="2rem"
               alertHeader={ALERT.HEADER}
-              alertContents={ALERT.CONTENTS}
+              alertContents={ALERT.NEUN_CONTENTS}
               highlight={target}
             />
           ) : (

--- a/apps/client/src/widgets/report/components/susul/components/sanghae-class.tsx
+++ b/apps/client/src/widgets/report/components/susul/components/sanghae-class.tsx
@@ -1,4 +1,7 @@
+import { Alert } from '@bds/ui';
+
 import { ACCORDION_CATEGORY } from '@widgets/report/constant/accordion-category-constant';
+import { ALERT } from '@widgets/report/constant/alert-content';
 
 import { InsuranceSusulReport } from '@shared/api/types/types';
 import { StatusType } from '@shared/types/type';
@@ -23,6 +26,8 @@ const SanghaeClass = ({ target, status, onClick, data }: SanghaeProps) => {
     (surgery) => surgery.productCoverage ?? 0,
   );
 
+  const hasCoverage = guaranteeValues.every((value) => value === 0);
+
   return (
     <div>
       <Accordion>
@@ -34,10 +39,21 @@ const SanghaeClass = ({ target, status, onClick, data }: SanghaeProps) => {
           {target}
         </Accordion.Header>
         <Accordion.Panel>
-          <Class
-            averageValues={averageValues}
-            guaranteeValues={guaranteeValues}
-          />
+          {hasCoverage ? (
+            <Alert
+              type="additional"
+              iconName="info_warning"
+              iconSize="2rem"
+              alertHeader={ALERT.HEADER}
+              alertContents={ALERT.NEUN_CONTENTS}
+              highlight={target}
+            />
+          ) : (
+            <Class
+              averageValues={averageValues}
+              guaranteeValues={guaranteeValues}
+            />
+          )}
         </Accordion.Panel>
       </Accordion>
     </div>

--- a/apps/client/src/widgets/report/components/susul/components/sanghae.tsx
+++ b/apps/client/src/widgets/report/components/susul/components/sanghae.tsx
@@ -35,7 +35,7 @@ const Sanghae = ({ target, status, data, onClick }: SanghaeClassProps) => {
               iconName="info_warning"
               iconSize="2rem"
               alertHeader={ALERT.HEADER}
-              alertContents={ALERT.CONTENTS}
+              alertContents={ALERT.NEUN_CONTENTS}
               highlight={target}
             />
           ) : (

--- a/apps/client/src/widgets/report/constant/alert-content.ts
+++ b/apps/client/src/widgets/report/constant/alert-content.ts
@@ -1,6 +1,7 @@
 export const ALERT = {
   HEADER: '참고하세요!',
-  CONTENTS: '은 이 보험에 포함되지 않아요.',
+  EUN_CONTENTS: '은 이 보험에 포함되지 않아요.',
+  NEUN_CONTENTS: '는 이 보험에 포함되지 않아요. ',
   SUSUL_CONTENTS: ' 수술비는 이 보험에 포함되지 않아요.',
   JINDAN_CONTENTS: ' 진단비는 이 보험에 포함되지 않아요.',
 };


### PR DESCRIPTION
## 📌 Summary

- #272 

보험 추천 리포트 페이지 QA를 반영

## 📚 Tasks

- 보험 추천 리포트 페이지 수술비 alert 문구 수술비 반영
- 종 수술비에서 보장 항목이 0일 때[질병/상해 종 수술비]은 이 보험에 포함되지 않아요.라고 alert 띄우기
- 아코디언 컴포넌트 화살표 클릭 시 open => 아코디언 헤더 클릭 시 open으로 수정
- CTA 버튼 상단에 텍스트에 쉼표 추가

<!--
## 👀 To Reviewer

(기재 내용 없을 경우 섹션 삭제) 더 전달할 내용 혹은 리뷰에게 요청하는 내용을 작성해주세요.
-->


## 🕶️ Requirements Checklist
- [x] 보험 추천 리포트 페이지 수술비 alert 문구 수술비 반영
- [x] 종 수술비에서 보장 항목이 0일 때[질병/상해 종 수술비]은 이 보험에 포함되지 않아요.라고 alert 띄우기
- [x] 아코디언 컴포넌트 화살표 클릭 시 open => 아코디언 헤더 클릭 시 open으로 수정
- [x] CTA 버튼 상단에 텍스트에 쉼표 추가


## 📸 Screenshot

<img width="344" height="362" alt="image" src="https://github.com/user-attachments/assets/252c1a65-7772-4b71-aeed-185ca7b38811" />

</br>

<img width="189" height="42" alt="image" src="https://github.com/user-attachments/assets/48a53db2-f5c1-4ea7-8aac-df8ade50e71d" />

</br>

<img width="343" height="134" alt="image" src="https://github.com/user-attachments/assets/0e21efb3-d4d2-4659-bf85-be39e614ae68" />

</br>

https://github.com/user-attachments/assets/8b362401-7f1d-4f2a-80f3-6f16ce135221



