### PR TITLE
QA-1: getTimeAgo 함수 형식 변경

### DIFF
--- a/apps/client/src/pages/community/community-detail/community-detail.tsx
+++ b/apps/client/src/pages/community/community-detail/community-detail.tsx
@@ -24,10 +24,10 @@ import {
 } from '@shared/api/domain/community/queries';
 import { POST_FEED_DETAIL_OPTIONS } from '@shared/api/domain/community/queries';
 import { USER_QUERY_OPTIONS } from '@shared/api/domain/onboarding/queries';
-import { getTimeAgo } from '@shared/api/utils/get-time-ago';
 import { useIntersectionObserver } from '@shared/hooks/use-intersection-observer';
 import { useLimitedInput } from '@shared/hooks/use-limited-input';
 import { routePath } from '@shared/router/path';
+import { getTimeAgo } from '@shared/utils/get-time-ago';
 
 import * as styles from './community-detail.css';
 

--- a/apps/client/src/shared/utils/get-time-ago.ts
+++ b/apps/client/src/shared/utils/get-time-ago.ts
@@ -2,12 +2,13 @@ export const getTimeAgo = (createdAt?: string): string => {
   if (!createdAt) {
     return '';
   }
+
   const now = new Date();
   const created = new Date(createdAt);
 
   const createdTime = created.getTime();
   if (isNaN(createdTime)) {
-    return '방금 전';
+    return '';
   }
 
   const diffMs = now.getTime() - created.getTime();
@@ -15,16 +16,18 @@ export const getTimeAgo = (createdAt?: string): string => {
   const diffSec = Math.floor(diffMs / 1000);
   const diffMin = Math.floor(diffSec / 60);
   const diffHour = Math.floor(diffMin / 60);
-  const diffDay = Math.floor(diffHour / 24);
 
-  if (diffSec < 60) {
-    return '방금 전';
+  if (diffHour < 1) {
+    return `${Math.max(1, diffMin)}분 전`;
   }
-  if (diffMin < 60) {
-    return `${diffMin}분 전`;
-  }
+
   if (diffHour < 24) {
     return `${diffHour}시간 전`;
   }
-  return `${diffDay}일 전`;
+
+  const year = created.getFullYear();
+  const month = String(created.getMonth() + 1).padStart(2, '0');
+  const day = String(created.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
 };

--- a/apps/client/src/widgets/community/components/detail-comment/detail-comment.tsx
+++ b/apps/client/src/widgets/community/components/detail-comment/detail-comment.tsx
@@ -1,7 +1,7 @@
 import { Avatar, Content, Title } from '@bds/ui';
 import { Icon } from '@bds/ui/icons';
 
-import { getTimeAgo } from '@shared/api/utils/get-time-ago';
+import { getTimeAgo } from '@shared/utils/get-time-ago';
 import { BULLET } from '@shared/constants/bullet';
 
 import * as styles from './detail-comment.css';

--- a/apps/client/src/widgets/community/components/detail-comment/detail-comment.tsx
+++ b/apps/client/src/widgets/community/components/detail-comment/detail-comment.tsx
@@ -1,8 +1,8 @@
 import { Avatar, Content, Title } from '@bds/ui';
 import { Icon } from '@bds/ui/icons';
 
-import { getTimeAgo } from '@shared/utils/get-time-ago';
 import { BULLET } from '@shared/constants/bullet';
+import { getTimeAgo } from '@shared/utils/get-time-ago';
 
 import * as styles from './detail-comment.css';
 

--- a/apps/client/src/widgets/mypage/comment-preview.tsx
+++ b/apps/client/src/widgets/mypage/comment-preview.tsx
@@ -1,6 +1,6 @@
 import { Title } from '@bds/ui';
 
-import { getTimeAgo } from '@shared/api/utils/get-time-ago';
+import { getTimeAgo } from '@shared/utils/get-time-ago';
 
 import * as styles from './comment-preview.css';
 import { contentText } from './post-preview.css';

--- a/apps/client/src/widgets/mypage/post-preview.tsx
+++ b/apps/client/src/widgets/mypage/post-preview.tsx
@@ -1,7 +1,7 @@
 import { Content, Title } from '@bds/ui';
 import { Icon } from '@bds/ui/icons';
 
-import { getTimeAgo } from '@shared/api/utils/get-time-ago';
+import { getTimeAgo } from '@shared/utils/get-time-ago';
 
 import * as styles from './post-preview.css';
 


### PR DESCRIPTION
## 📌 Summary

> - #276 

## 📚 Tasks

getTimeAgo 함수 형식을 변경하였습니다.
기존
- 1분 미만이면 “방금 전”
- 24시간 이상이면 “며칠 전” (예: 3일 전) 로 표기.

수정
- 1분 미만도 무조건 “1분 전” 로 처리.
- “방금 전” 은 사라짐.
- 24시간 이상은 더 이상 “며칠 전”이 아니라, 절대적인 날짜 (YYYY-MM-DD)로 표기.

<!--
## 👀 To Reviewer

(기재 내용 없을 경우 섹션 삭제) 더 전달할 내용 혹은 리뷰에게 요청하는 내용을 작성해주세요.
-->

<!--
## 🕶️ Requirements Checklist
- [ ]

(기능 명세서상 내용을 복사해서 테스트해주세요)
-->


## 📸 Screenshot
[수정후]
<img width="425" height="225" alt="image" src="https://github.com/user-attachments/assets/218b7574-ada7-4c14-b415-76d87e11747b" />
<img width="434" height="139" alt="image" src="https://github.com/user-attachments/assets/285c879f-429f-466b-adae-6dc09f1e7ccc" />

