### PR TITLE
Fix(client): 로그인 이미지 높이 맞추기 및 이미지 크기 조정

### DIFF
--- a/apps/client/src/widgets/login/components/login-slide/login-slide.tsx
+++ b/apps/client/src/widgets/login/components/login-slide/login-slide.tsx
@@ -34,7 +34,7 @@ const LoginSlide = () => {
             <section className={styles.slideImageSection}>
               <img
                 src={LOGIN_TEXT.IMAGE_URL[idx]}
-                width={'65%'}
+                width={'62%'}
                 alt={LOGIN_TEXT.ALT_TAG[idx]}
               />
               <div className={styles.contentTextContainer}>

--- a/apps/client/src/widgets/login/components/login-slide/sub-title.css.ts
+++ b/apps/client/src/widgets/login/components/login-slide/sub-title.css.ts
@@ -4,6 +4,8 @@ import { themeVars } from '@bds/ui/styles';
 
 export const descriptionText = style({
   width: '100%',
+  height: '100%',
+  minHeight: '4.8rem',
   ...themeVars.fontStyles.body1_m_16,
   color: themeVars.color.gray600,
   whiteSpace: 'pre-wrap',


### PR DESCRIPTION
## 📌 Summary

- #336 

로그인 캐러셀 이미지 두개의 끝 높이를 맞추고, 이미지 크기를 3% 줄여 위의 여백을 두었습니다


