### PR TITLE
Refactor(client): 커뮤니티 쿼리키 통합

### DIFF
--- a/apps/client/src/shared/api/domain/community/queries.ts
+++ b/apps/client/src/shared/api/domain/community/queries.ts
@@ -6,10 +6,7 @@ import {
 
 import { END_POINT } from '@shared/api/config/end-point';
 import { api } from '@shared/api/config/instance';
-import {
-  COMMUNITY_QUERY_KEY,
-  POST_FEED_DETAIL_KEY,
-} from '@shared/api/keys/query-key';
+import { COMMUNITY_QUERY_KEY } from '@shared/api/keys/query-key';
 import {
   CommentDeleteResponse,
   CommentPostResponse,
@@ -26,7 +23,7 @@ import {
 export const POST_FEED_DETAIL_OPTIONS = {
   DETAIL: (postId: string) => {
     return queryOptions({
-      queryKey: POST_FEED_DETAIL_KEY.DETAIL(postId).concat(),
+      queryKey: COMMUNITY_QUERY_KEY.FEED_DETAIL(postId).concat(),
       queryFn: () => getFeedDeatil(postId),
     });
   },
@@ -65,7 +62,7 @@ export const POST_COMMENT = (onSuccessCallback?: () => void) => {
         queryKey: COMMUNITY_QUERY_KEY.COMMENTS(variables.postId),
       });
       queryClient.invalidateQueries({
-        queryKey: POST_FEED_DETAIL_KEY.DETAIL(variables.postId),
+        queryKey: COMMUNITY_QUERY_KEY.FEED_DETAIL(variables.postId),
       });
       if (onSuccessCallback) {
         onSuccessCallback();
@@ -116,7 +113,7 @@ export const PUT_FEED = (onSuccessCallback?: () => void) => {
     }) => putFeed(postId, body),
     onSuccess: async (_data, variables) => {
       await queyrClient.invalidateQueries({
-        queryKey: POST_FEED_DETAIL_KEY.DETAIL(variables.postId),
+        queryKey: COMMUNITY_QUERY_KEY.FEED_DETAIL(variables.postId),
       });
 
       if (onSuccessCallback) {
@@ -132,7 +129,7 @@ export const COMMUNITY_QUERY_OPTIONS = {
     queryFn: ({ pageParam = 0 }) => getAllComments(postId, { pageParam }),
   }),
   POSTS: () => ({
-    queryKey: POST_FEED_DETAIL_KEY.FEED(),
+    queryKey: COMMUNITY_QUERY_KEY.FEED_PREVIEW(),
     queryFn: ({ pageParam = 0 }) =>
       getAllPosts({ pageParam: pageParam as number }),
   }),
@@ -213,7 +210,7 @@ export const useDeleteComment = (
         queryKey: COMMUNITY_QUERY_KEY.COMMENTS(postId),
       });
       await queryClient.invalidateQueries({
-        queryKey: POST_FEED_DETAIL_KEY.DETAIL(postId),
+        queryKey: COMMUNITY_QUERY_KEY.FEED_DETAIL(postId),
       });
 
       if (onSuccessCallback) {

--- a/apps/client/src/shared/api/keys/query-key.ts
+++ b/apps/client/src/shared/api/keys/query-key.ts
@@ -22,7 +22,12 @@ export const USER_QUERY_KEY = {
 
 export const COMMUNITY_QUERY_KEY = {
   ALL: ['community'],
-  FEED: () => [...COMMUNITY_QUERY_KEY.ALL, 'feed'],
+  FEED_PREVIEW: () => [...COMMUNITY_QUERY_KEY.ALL, 'feed'],
+  FEED_DETAIL: (postId: string) => [
+    ...COMMUNITY_QUERY_KEY.ALL,
+    'detail',
+    postId,
+  ],
   COMMENTS: (postId?: string) => [
     ...COMMUNITY_QUERY_KEY.ALL,
     'comment',
@@ -34,9 +39,3 @@ export const HOME_QUERY_KEY = {
   ALL: ['home'],
   REPORT_SUMMARY: () => [...HOME_QUERY_KEY.ALL, 'report_summary'],
 } as const;
-
-export const POST_FEED_DETAIL_KEY = {
-  ALL: ['details'],
-  DETAIL: (postId: string) => [...POST_FEED_DETAIL_KEY.ALL, 'detail', postId],
-  FEED: () => [...POST_FEED_DETAIL_KEY.ALL, 'feed'],
-};

--- a/apps/client/src/widgets/login/components/login-slide/login-slide.tsx
+++ b/apps/client/src/widgets/login/components/login-slide/login-slide.tsx
@@ -24,7 +24,6 @@ const LoginSlide = () => {
     <div className={styles.body}>
       <Swiper
         modules={[Autoplay, Pagination]}
-        pagination={{ clickable: true }}
         autoplay={{ delay: 5000, stopOnLastSlide: true }}
         speed={500}
         onSlideChange={handleSlideChange}


### PR DESCRIPTION
## 📌 Summary

- #341 

## 📚 Tasks

- POST_FEED_DETAIL_KEY 를 커뮤니티 쿼리키로 통합 및 login 슬라이더의 불필요한 코드제거

## 👀 To Reviewer

기존에 POST_FEED_DETAIL_KEY 를 커뮤니티 쿼리키 객체 안으로 통합하고, POST (게시글) 워딩을 FEED 로 수정하였어요 POST 는 HTTP 메소드와 겹치기 때문에 게시글을 표현할 때는 FEED 로 통합하는게 좋을 듯 싶어요 우선 해당 PR에서는 쿼리 키 관련 된 부분만 정리하였고, 

queries 파일은 전체적으로 TanStack Query v5.82.0 부터 추가 된 mutationOptions 를 사용하여 리팩토링 예정입니다. 다음 작업으로 진행할게요 
