### PR TITLE
Refactor(client): 아코디언 애니메이션 ux 개선

### DIFF
--- a/apps/client/src/widgets/report/components/accordion/accordion.css.ts
+++ b/apps/client/src/widgets/report/components/accordion/accordion.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css';
+import { keyframes, style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
 import { themeVars } from '@bds/ui/styles';
@@ -34,25 +34,41 @@ export const icon = style({
   transition: 'transform 0.3s ease',
 });
 
-export const panelContainer = recipe({
+const accordionDown = keyframes({
+  '0%': { height: '0' },
+  '100%': { height: 'var(--accordion-height)' },
+});
+
+const accordionUp = keyframes({
+  '0%': { height: 'var(--accordion-height)' },
+  '100%': { height: '0' },
+});
+
+export const panelAllContainer = recipe({
   base: {
     overflow: 'hidden',
-    transition: 'max-height 0.2s ease, opacity 0.25s ease, padding 0.3s ease',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '2.4rem',
+    height: 'var(--accordion-height, 0)',
+    transition: 'height 0.35s ease, opacity 0.35s ease',
   },
   variants: {
-    expanded: {
+    isOpen: {
       true: {
-        maxHeight: '90rem',
+        display: 'block',
         opacity: 1,
-        paddingTop: '2.4rem ',
+        animation: `${accordionDown} 0.35s ease forwards`,
       },
       false: {
-        maxHeight: '0',
-        opacity: '0',
+        display: 'none',
+        opacity: 0,
+        animation: `${accordionUp} 0.35s ease forwards`,
       },
     },
   },
+});
+
+export const panelContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '2.4rem',
+  paddingTop: '1.6rem',
 });

--- a/apps/client/src/widgets/report/components/accordion/accordion.tsx
+++ b/apps/client/src/widgets/report/components/accordion/accordion.tsx
@@ -26,6 +26,7 @@ interface accordionHeaderProps {
 
 interface accordionPanelProps {
   children: ReactNode;
+  hasData: boolean;
 }
 
 export const Accordion = ({ children }: accordionProps) => {
@@ -71,9 +72,12 @@ export const AccordionHeader = ({
   );
 };
 
-export const AccordionPanel = ({ children }: accordionPanelProps) => {
+export const AccordionPanel = ({ children, hasData }: accordionPanelProps) => {
   const { isOpen } = useAccordionContext();
-  const { contentRef } = useAccordionHeight<HTMLDivElement>(isOpen, 200);
+  const { contentRef } = useAccordionHeight<HTMLDivElement>({
+    isOpen,
+    hasData,
+  });
 
   return (
     <div className={styles.panelAllContainer({ isOpen })}>

--- a/apps/client/src/widgets/report/components/accordion/accordion.tsx
+++ b/apps/client/src/widgets/report/components/accordion/accordion.tsx
@@ -27,10 +27,8 @@ interface accordionPanelProps {
   children: ReactNode;
 }
 
-export const Accordion = ({
-  children,
-  defaultExpanded = false,
-}: accordionProps) => {
+export const Accordion = ({ children }: accordionProps) => {
+  const defaultExpanded = false;
   return (
     <AccordionContextProvider defaultExpanded={defaultExpanded}>
       <div className={styles.accordionContainer}>{children}</div>
@@ -73,9 +71,7 @@ export const AccordionHeader = ({
 };
 
 export const AccordionPanel = ({ children }: accordionPanelProps) => {
-  const { expanded } = useAccordionContext();
-
-  return <div className={styles.panelContainer({ expanded })}>{children}</div>;
+  return <div className={styles.panelContainer}>{children}</div>;
 };
 
 Accordion.Header = AccordionHeader;

--- a/apps/client/src/widgets/report/components/accordion/accordion.tsx
+++ b/apps/client/src/widgets/report/components/accordion/accordion.tsx
@@ -7,6 +7,7 @@ import { StatusType } from '@shared/types/type';
 import Chip from '../chip/chip';
 import Title from '../title/title';
 import { AccordionContextProvider } from './context-provider';
+import { useAccordionHeight } from './hooks/use-accordion-height';
 import { useAccordionContext } from './hooks/use-context';
 
 import * as styles from './accordion.css';
@@ -29,6 +30,7 @@ interface accordionPanelProps {
 
 export const Accordion = ({ children }: accordionProps) => {
   const defaultExpanded = false;
+
   return (
     <AccordionContextProvider defaultExpanded={defaultExpanded}>
       <div className={styles.accordionContainer}>{children}</div>
@@ -42,15 +44,14 @@ export const AccordionHeader = ({
   accordionCategory,
   onClick,
 }: accordionHeaderProps) => {
-  const { expanded, handleClick } = useAccordionContext();
+  const { isOpen, handleClick } = useAccordionContext();
 
   const handleAccordionClick = () => {
-    handleClick();
     if (accordionCategory) {
       onClick?.(accordionCategory);
     }
+    handleClick();
   };
-
   return (
     <div className={styles.headerContainer} onClick={handleAccordionClick}>
       <div className={styles.headerContentsContainer}>
@@ -63,7 +64,7 @@ export const AccordionHeader = ({
           name="caret_up_lg"
           size="2.4rem"
           color="gray800"
-          rotate={expanded ? undefined : 180}
+          rotate={isOpen ? undefined : 180}
         />
       </div>
     </div>
@@ -71,7 +72,16 @@ export const AccordionHeader = ({
 };
 
 export const AccordionPanel = ({ children }: accordionPanelProps) => {
-  return <div className={styles.panelContainer}>{children}</div>;
+  const { isOpen } = useAccordionContext();
+  const { contentRef } = useAccordionHeight<HTMLDivElement>(isOpen, 200);
+
+  return (
+    <div className={styles.panelAllContainer({ isOpen })}>
+      <div ref={contentRef} className={styles.panelContainer}>
+        {children}
+      </div>
+    </div>
+  );
 };
 
 Accordion.Header = AccordionHeader;

--- a/apps/client/src/widgets/report/components/accordion/context-provider.tsx
+++ b/apps/client/src/widgets/report/components/accordion/context-provider.tsx
@@ -10,13 +10,14 @@ export const AccordionContextProvider = ({
   children,
   defaultExpanded,
 }: AccordionContextProviderProps) => {
-  const [expanded, setExpanded] = useState(defaultExpanded);
+  const [isOpen, setExpanded] = useState(defaultExpanded);
 
   const handleClick = () => {
     setExpanded((prev) => !prev);
   };
+
   return (
-    <AccordionContext.Provider value={{ expanded, handleClick }}>
+    <AccordionContext.Provider value={{ isOpen, handleClick }}>
       {children}
     </AccordionContext.Provider>
   );

--- a/apps/client/src/widgets/report/components/accordion/context-provider.tsx
+++ b/apps/client/src/widgets/report/components/accordion/context-provider.tsx
@@ -8,7 +8,7 @@ interface AccordionContextProviderProps {
 }
 export const AccordionContextProvider = ({
   children,
-  defaultExpanded = false,
+  defaultExpanded,
 }: AccordionContextProviderProps) => {
   const [expanded, setExpanded] = useState(defaultExpanded);
 

--- a/apps/client/src/widgets/report/components/accordion/hooks/use-accordion-height.tsx
+++ b/apps/client/src/widgets/report/components/accordion/hooks/use-accordion-height.tsx
@@ -1,9 +1,14 @@
 import { useEffect, useRef } from 'react';
 
-export const useAccordionHeight = <T extends HTMLElement>(
-  isOpen: boolean,
-  duration: number,
-) => {
+interface UseAccordionHeightProps {
+  isOpen: boolean;
+  hasData: boolean;
+}
+
+export const useAccordionHeight = <T extends HTMLElement>({
+  isOpen,
+  hasData,
+}: UseAccordionHeightProps) => {
   const contentRef = useRef<T>(null);
 
   useEffect(() => {
@@ -24,9 +29,9 @@ export const useAccordionHeight = <T extends HTMLElement>(
       parentElement.style.setProperty('--accordion-height', `0`);
       setTimeout(() => {
         parentElement.style.display = 'none';
-      }, duration);
+      }, 200);
     }
-  }, [isOpen]);
+  }, [isOpen, hasData]);
 
   return { contentRef };
 };

--- a/apps/client/src/widgets/report/components/accordion/hooks/use-accordion-height.tsx
+++ b/apps/client/src/widgets/report/components/accordion/hooks/use-accordion-height.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+
+export const useAccordionHeight = <T extends HTMLElement>(
+  isOpen: boolean,
+  duration: number,
+) => {
+  const contentRef = useRef<T>(null);
+
+  useEffect(() => {
+    const element = contentRef.current;
+    if (!element || !element.parentElement) {
+      return;
+    }
+    const { parentElement } = element;
+
+    if (isOpen) {
+      parentElement.style.display = 'block';
+
+      requestAnimationFrame(() => {
+        const height = element.clientHeight;
+        parentElement.style.setProperty('--accordion-height', `${height}px`);
+      });
+    } else {
+      parentElement.style.setProperty('--accordion-height', `0`);
+      setTimeout(() => {
+        parentElement.style.display = 'none';
+      }, duration);
+    }
+  }, [isOpen]);
+
+  return { contentRef };
+};

--- a/apps/client/src/widgets/report/components/accordion/hooks/use-context.tsx
+++ b/apps/client/src/widgets/report/components/accordion/hooks/use-context.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext } from 'react';
 
 interface useAccordionContextProps {
-  expanded: boolean;
+  isOpen: boolean;
   handleClick: () => void;
 }
 

--- a/apps/client/src/widgets/report/components/ipwon/components/jilbyeong.tsx
+++ b/apps/client/src/widgets/report/components/ipwon/components/jilbyeong.tsx
@@ -18,6 +18,7 @@ interface JilbyeongProps {
 
 const Jilbyeong = ({ target, status, onClick, data }: JilbyeongProps) => {
   const hasCoverage = data?.diseaseDailyHospitalization?.productCoverage == 0;
+  const hasData = !!data;
 
   return (
     <Accordion>
@@ -28,7 +29,7 @@ const Jilbyeong = ({ target, status, onClick, data }: JilbyeongProps) => {
       >
         {target}
       </Accordion.Header>
-      <Accordion.Panel>
+      <Accordion.Panel hasData={hasData}>
         {hasCoverage ? (
           <Alert
             type="additional"

--- a/apps/client/src/widgets/report/components/ipwon/components/sanghae.tsx
+++ b/apps/client/src/widgets/report/components/ipwon/components/sanghae.tsx
@@ -18,6 +18,7 @@ interface SanghaeProps {
 
 const Sanghae = ({ target, status, onClick, data }: SanghaeProps) => {
   const hasCoverage = data?.diseaseDailyHospitalization?.productCoverage == 0;
+  const hasData = !!data;
   return (
     <Accordion>
       <Accordion.Header
@@ -27,7 +28,7 @@ const Sanghae = ({ target, status, onClick, data }: SanghaeProps) => {
       >
         {target}
       </Accordion.Header>
-      <Accordion.Panel>
+      <Accordion.Panel hasData={hasData}>
         {hasCoverage ? (
           <Alert
             type="additional"

--- a/apps/client/src/widgets/report/components/janghae/components/jilbyeong.tsx
+++ b/apps/client/src/widgets/report/components/janghae/components/jilbyeong.tsx
@@ -18,6 +18,7 @@ interface JilbyeongProps {
 
 const Jilbyeong = ({ onClick, data, target, status }: JilbyeongProps) => {
   const hasCoverage = data?.coverage?.productCoverage == 0;
+  const hasData = !!data;
   return (
     <Accordion>
       <Accordion.Header
@@ -27,7 +28,7 @@ const Jilbyeong = ({ onClick, data, target, status }: JilbyeongProps) => {
       >
         {target}
       </Accordion.Header>
-      <Accordion.Panel>
+      <Accordion.Panel hasData={hasData}>
         {hasCoverage ? (
           <Alert
             type="additional"

--- a/apps/client/src/widgets/report/components/janghae/components/sanghae.tsx
+++ b/apps/client/src/widgets/report/components/janghae/components/sanghae.tsx
@@ -18,6 +18,7 @@ interface SanghaeProps {
 
 const Sanghae = ({ onClick, data, target, status }: SanghaeProps) => {
   const hasCoverage = data?.coverage?.productCoverage == 0;
+  const hasData = !!data;
   return (
     <Accordion>
       <Accordion.Header
@@ -27,7 +28,7 @@ const Sanghae = ({ onClick, data, target, status }: SanghaeProps) => {
       >
         {target}
       </Accordion.Header>
-      <Accordion.Panel>
+      <Accordion.Panel hasData={hasData}>
         {hasCoverage ? (
           <Alert
             type="additional"

--- a/apps/client/src/widgets/report/components/keunbyeong/components/cancer.tsx
+++ b/apps/client/src/widgets/report/components/keunbyeong/components/cancer.tsx
@@ -23,6 +23,7 @@ interface CancerProps {
 
 const Cancer = ({ onClick, data, target, status }: CancerProps) => {
   const hasCoverage = useCoverage({ sections: data?.sections });
+  const hasData = !!data;
 
   return (
     <Accordion>
@@ -33,8 +34,14 @@ const Cancer = ({ onClick, data, target, status }: CancerProps) => {
       >
         {target}
       </Accordion.Header>
-      <Accordion.Panel>
-        <Info description={data?.additionalInfo} size="sm" iconSize="1.6rem" />
+      <Accordion.Panel hasData={hasData}>
+        {data && data?.additionalInfo && (
+          <Info
+            description={data?.additionalInfo}
+            size="sm"
+            iconSize="1.6rem"
+          />
+        )}
         <div className={styles.allgraphContainer}>
           {data?.sections?.map(({ displayName, diagnosis, injury }) => {
             if (!displayName) {

--- a/apps/client/src/widgets/report/components/keunbyeong/components/noehyeolgwan.tsx
+++ b/apps/client/src/widgets/report/components/keunbyeong/components/noehyeolgwan.tsx
@@ -23,6 +23,7 @@ interface NoehyeolgwanProps {
 
 const Noehyeolgwan = ({ onClick, data, target, status }: NoehyeolgwanProps) => {
   const hasCoverage = useCoverage({ sections: data?.sections });
+  const hasData = !!data;
 
   return (
     <Accordion>
@@ -33,8 +34,14 @@ const Noehyeolgwan = ({ onClick, data, target, status }: NoehyeolgwanProps) => {
       >
         {target}
       </Accordion.Header>
-      <Accordion.Panel>
-        <Info description={data?.additionalInfo} size="sm" iconSize="1.6rem" />
+      <Accordion.Panel hasData={hasData}>
+        {data && data?.additionalInfo && (
+          <Info
+            description={data?.additionalInfo}
+            size="sm"
+            iconSize="1.6rem"
+          />
+        )}
         <div className={styles.allgraphContainer}>
           {data?.sections?.map(({ displayName, diagnosis, injury }) => {
             if (!displayName) {

--- a/apps/client/src/widgets/report/components/keunbyeong/components/shimjang.tsx
+++ b/apps/client/src/widgets/report/components/keunbyeong/components/shimjang.tsx
@@ -23,7 +23,7 @@ interface ShimjangProps {
 
 const Shimjang = ({ onClick, data, target, status }: ShimjangProps) => {
   const hasCoverage = useCoverage({ sections: data?.sections });
-
+  const hasData = !!data;
   return (
     <Accordion>
       <Accordion.Header
@@ -33,8 +33,14 @@ const Shimjang = ({ onClick, data, target, status }: ShimjangProps) => {
       >
         {target}
       </Accordion.Header>
-      <Accordion.Panel>
-        <Info description={data?.additionalInfo} size="sm" iconSize="1.6rem" />
+      <Accordion.Panel hasData={hasData}>
+        {data && data?.additionalInfo && (
+          <Info
+            description={data?.additionalInfo}
+            size="sm"
+            iconSize="1.6rem"
+          />
+        )}
         <div className={styles.allgraphContainer}>
           {data?.sections?.map(({ displayName, diagnosis, injury }) => {
             if (!displayName) {

--- a/apps/client/src/widgets/report/components/samang/components/jilbyeong.tsx
+++ b/apps/client/src/widgets/report/components/samang/components/jilbyeong.tsx
@@ -18,7 +18,7 @@ interface JilbyeongProps {
 
 const Jilbyeong = ({ target, status, onClick, data }: JilbyeongProps) => {
   const hasCoverage = data?.coverage?.productCoverage == 0;
-
+  const hasData = !!data;
   return (
     <Accordion>
       <Accordion.Header
@@ -28,7 +28,7 @@ const Jilbyeong = ({ target, status, onClick, data }: JilbyeongProps) => {
       >
         {target}
       </Accordion.Header>
-      <Accordion.Panel>
+      <Accordion.Panel hasData={hasData}>
         {hasCoverage ? (
           <Alert
             type="additional"

--- a/apps/client/src/widgets/report/components/samang/components/sanghae.tsx
+++ b/apps/client/src/widgets/report/components/samang/components/sanghae.tsx
@@ -18,6 +18,7 @@ interface SanghaeProps {
 
 const Sanghae = ({ target, status, onClick, data }: SanghaeProps) => {
   const hasCoverage = data?.coverage?.productCoverage == 0;
+  const hasData = !!data;
   return (
     <Accordion>
       <Accordion.Header
@@ -27,7 +28,7 @@ const Sanghae = ({ target, status, onClick, data }: SanghaeProps) => {
       >
         {target}
       </Accordion.Header>
-      <Accordion.Panel>
+      <Accordion.Panel hasData={hasData}>
         {hasCoverage ? (
           <Alert
             type="additional"

--- a/apps/client/src/widgets/report/components/susul/components/jilbyeong-class.tsx
+++ b/apps/client/src/widgets/report/components/susul/components/jilbyeong-class.tsx
@@ -27,6 +27,7 @@ const JilbyeongClass = ({ onClick, data, target, status }: JilbyeongProps) => {
   );
 
   const hasCoverage = guaranteeValues.every((value) => value === 0);
+  const hasData = !!data;
 
   return (
     <div>
@@ -38,7 +39,7 @@ const JilbyeongClass = ({ onClick, data, target, status }: JilbyeongProps) => {
         >
           {target}
         </Accordion.Header>
-        <Accordion.Panel>
+        <Accordion.Panel hasData={hasData}>
           {hasCoverage ? (
             <Alert
               type="additional"

--- a/apps/client/src/widgets/report/components/susul/components/jilbyeong.tsx
+++ b/apps/client/src/widgets/report/components/susul/components/jilbyeong.tsx
@@ -18,6 +18,7 @@ interface JilbyeongClassProps {
 
 const Jilbyeong = ({ target, status, onClick, data }: JilbyeongClassProps) => {
   const hasCoverage = data?.surgery?.productCoverage == 0;
+  const hasData = !!data;
 
   return (
     <>
@@ -29,7 +30,7 @@ const Jilbyeong = ({ target, status, onClick, data }: JilbyeongClassProps) => {
         >
           {target}
         </Accordion.Header>
-        <Accordion.Panel>
+        <Accordion.Panel hasData={hasData}>
           {hasCoverage ? (
             <Alert
               type="additional"

--- a/apps/client/src/widgets/report/components/susul/components/sanghae-class.tsx
+++ b/apps/client/src/widgets/report/components/susul/components/sanghae-class.tsx
@@ -27,6 +27,7 @@ const SanghaeClass = ({ target, status, onClick, data }: SanghaeProps) => {
   );
 
   const hasCoverage = guaranteeValues.every((value) => value === 0);
+  const hasData = !!data;
 
   return (
     <div>
@@ -38,7 +39,7 @@ const SanghaeClass = ({ target, status, onClick, data }: SanghaeProps) => {
         >
           {target}
         </Accordion.Header>
-        <Accordion.Panel>
+        <Accordion.Panel hasData={hasData}>
           {hasCoverage ? (
             <Alert
               type="additional"

--- a/apps/client/src/widgets/report/components/susul/components/sanghae.tsx
+++ b/apps/client/src/widgets/report/components/susul/components/sanghae.tsx
@@ -18,6 +18,7 @@ interface SanghaeClassProps {
 
 const Sanghae = ({ target, status, data, onClick }: SanghaeClassProps) => {
   const hasCoverage = data?.surgery?.productCoverage == 0;
+  const hasData = !!data;
   return (
     <div>
       <Accordion>
@@ -28,7 +29,7 @@ const Sanghae = ({ target, status, data, onClick }: SanghaeClassProps) => {
         >
           {target}
         </Accordion.Header>
-        <Accordion.Panel>
+        <Accordion.Panel hasData={hasData}>
           {hasCoverage ? (
             <Alert
               type="additional"


### PR DESCRIPTION
## 📌 Summary

- close #349 

- 보험 추천 리포트 페이지에서 사용하고 있는 아코디언의 애니메이션 ux를 개선합니다.

## 📚 Tasks

- 아코디언 패널에 해당하는 컨텐츠의 height을 계산하는 훅 구현

## 아코디언 애니메이션의 문제점
아코디언을 처음 열고 닫을 때 애니메이션이 부드럽지 않고 뚝뚝 끊기며 버벅거리는 문제가 있었습니다. 


https://github.com/user-attachments/assets/c8062084-60ee-4219-a780-aac3e21ac70e

처음에는 애니메이션 자체의 문제인지, 데이터 fetching 과정에서 발생하는 문제인지 확인하기 위해 CSS 기반 애니메이션 코드를 제거하고 테스트했습니다. 그 결과, 데이터 자체는 빠르게 화면에 표시되고 있다는 것을 확인했습니다.

(데이터 확인을 위해 임시로 배경색을 red로 지정함)

https://github.com/user-attachments/assets/0154f0ab-c705-493b-a159-25f0a51656c2

아코디언이 열리고 닫힐 때 자연스럽고 부드러운 애니메이션을 구현하기 위해서는 해당하는 contents의 height 값을 정확하게 알아야 하는데 기존에는 임의의 `max-height: 90rem`을 지정하여 아코디언 패널의 height 값을 정확히 계산하지 못했습니다... 
그리고 아코디언 패널 hidden으로 숨겨져 있는 부분에 데이터가 들어오기 전에 alert 컴포넌트가 이미 존재하고 있어서 처음에는 alert 컴포넌트를 기준으로 height을 계산했다가 데이터가 들어온 이후에는 데이터 fetching 이후의 height 기준으로 계산을 하다보니 타이밍이 조금이라도 어긋나면 버벅거리는 현상이 극대화되어 아코디언 내부에 있는 alert 컴포넌트는 데이터가 존재할 때만 렌더링 되도록 수정해야했습니다.

> 접근 방안

1. 데이터를 불러오기 전, 예상 height을 미리 계산해 아코디언에 적용
2. 데이터 로드 후 임의의 지연 시간을 두고 height 계산 및 애니메이션 실행

1번은 구현 난이도가 어렵다고 생각하였고, 2번은 구현은 간단하지만 지연 시간을 임의로 설정하는 방식이라 비효율적이라고 판단했습니다.
따라서 **데이터 로드 후 height을 정확히 측정하는 방식(1번)을 선택**했습니다.

## 해결과정
다음과 같이 height 계산 전용 훅을 구현했습니다.
```tsx
import { useEffect, useRef } from 'react';

export const useAccordionHeight = <T extends HTMLElement>(
  isOpen: boolean,
  duration: number,
) => {
  const contentRef = useRef<T>(null);

  useEffect(() => {
    const element = contentRef.current;

    if (element === null || !element.parentElement) {
      return;
    }
    const { parentElement } = element;

    if (isOpen) {
      parentElement.style.display = 'block';

      requestAnimationFrame(() => {
        const height = element.clientHeight;
        parentElement.style.setProperty('--accordion-height', `${height}px`);
      });
    } else {
      parentElement.style.setProperty('--accordion-height', `0`);
      setTimeout(() => {
        parentElement.style.display = 'none';
      }, duration);
    }
  }, [isOpen]);

  return { contentRef };
};
```
> 코드 설명

먼저 아코디언 패널 요소를 element 변수에 담습니다. 만약 이 요소가 존재하지 않거나 상위 요소가 없다면, 안전을 위해 바로 return 하여 이후 로직을 실행하지 않습니다. 
요소가 존재한다면, isOpen이 true일 경우(즉, 아코디언을 열 때) 패널을 display: block으로 설정해 높이 계산이 가능하도록 만든 뒤, 콘텐츠의 실제 clientHeight를 측정합니다. 반대로 isOpen이 false일 경우에는 패널의 높이를 0으로 설정하고, 애니메이션 지속 시간만큼 기다린 뒤 display: none으로 변경하여 패널을 닫습니다.

> 또 다른 문제점..

하지만 두번째 클릭 이후부터 데이터의 올바른 height을 계산하는 문제가 생겼습니다..

https://github.com/user-attachments/assets/3f465240-8ef7-4e39-bfdc-6178d3e82f0e

이 문제가 발생한 원인은 데이터 fetching 타이밍과 height 계산 타이밍이 어긋났기 때문입니다. 아코디언 헤더를 클릭하면 특정 파라미터를 전달해 get 요청을 보내고, 그 결과로 데이터가 도착하는데, 이 데이터 로딩 과정과 height 계산이 실행되는 시점이 맞지 않아 충돌이 발생한 것 같습니다.

- `AccordionHeader` 클릭 →
    - `onClick(accordionCategory)` 실행 → 상위에서 `accordionCategory` 상태 변경
    - `handleClick()` 실행 → 아코디언 열림 상태(isOpen) true로 변경
- `isOpen`이 true → `useAccordionHeight` 실행 → `clientHeight` 측정
    
    **하지만 아직 `data`가 도착하기 전이라 DOM 높이가 0 또는 미완성 상태**
    
- height=0으로 기록됨 → 아코디언이 안 열림
- React Query가 데이터를 불러옴 → 다음 클릭 때는 DOM이 완성되어 clientHeight를 제대로 측정 → 정상 동작

따라서 height 계산을 데이터가 준비된 직후에 하도록 순서를 조정하였습니다.

```tsx
import { useEffect, useRef } from 'react';

interface UseAccordionHeightProps {
  isOpen: boolean;
  hasData: boolean;
}

export const useAccordionHeight = <T extends HTMLElement>({
  isOpen,
  hasData,
}: UseAccordionHeightProps) => {
  const contentRef = useRef<T>(null);

  useEffect(() => {
    const element = contentRef.current;
    if (!element || !element.parentElement) {
      return;
    }
    const { parentElement } = element;

    if (isOpen) {
      parentElement.style.display = 'block';

      requestAnimationFrame(() => {
        const height = element.clientHeight;
        parentElement.style.setProperty('--accordion-height', `${height}px`);
      });
    } else {
      parentElement.style.setProperty('--accordion-height', `0`);
      setTimeout(() => {
        parentElement.style.display = 'none';
      }, 200);
    }
  }, [isOpen, hasData]);

  return { contentRef };
};
```

`useAccordionHeight`에 `data`를 의존성으로 추가하는 방법을 선택했습니다.

데이터가 갱신될 때마다 다시 높이를 재계산해서 첫 클릭 시에도 올바른 높이가 적용되도록 했습니다.

## To Reviewer

- 이거 구현하면서 생겼던 모든 일을 한 번 기록해보고 싶어서 좀 많이 길어졌습니다... 

- `hasData` 값은 한 번만 변경되기 때문에, `useEffect` 의존성 배열에 넣는 것이 적절한지 고민이 됩니다.  혹시 이보다 더 좋은 해결 방법이 있다면 알려주시면 감사하겠습니다…

- 아코디언의 컴파운드 패턴을 추가적으로 따로 수정하려고 합니다.. 일단 아코디언 ux 개선을 중점으로 코드 리뷰 해주시면 정말 감사하겠습니다….

- 조금 더 수정하고 싶어서 일단은 draft 해놓을게요...ㅎㅎ draft 풀리기 전에 **여유롭게** 확인해주시면 감사할 것 같아요...

## 📸 Screenshot

https://github.com/user-attachments/assets/01a32798-8cd1-4a5c-9608-7f167d490969


