### PR TITLE
Feat(*): pnpm 카탈로그 설정

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -30,16 +30,16 @@
     "@pivanov/vite-plugin-svg-sprite": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^5.59.0",
     "@typescript-eslint/parser": "^5.59.0",
-    "@vanilla-extract/css": "*",
-    "@vanilla-extract/recipes": "^0.5.7",
-    "@vanilla-extract/sprinkles": "*",
-    "@vanilla-extract/vite-plugin": "*",
-    "@vitejs/plugin-react": "*",
+    "@vanilla-extract/css": "catalog:vanilla-extract-core",
+    "@vanilla-extract/recipes": "catalog:vanilla-extract-core",
+    "@vanilla-extract/sprinkles": "catalog:vanilla-extract-utils",
+    "@vanilla-extract/vite-plugin": "catalog:vanilla-extract-utils",
+    "vite": "catalog:vite-core",
+    "@vitejs/plugin-react": "catalog:vite-plugins",
     "eslint": "^8.44.0",
     "globals": "^16.2.0",
     "openapi-typescript": "^7.8.0",
     "typescript": "~5.8.3",
-    "vite": "*",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -14,15 +14,15 @@
     "@tanstack/react-query": "^5.83.0",
     "@tanstack/react-query-devtools": "^5.83.0",
     "@toss/ky": "^1.2.1",
-    "@types/react": "^19.1.8",
-    "@types/react-dom": "^19.1.6",
     "lottie-react": "^2.4.1",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
+    "react": "catalog:react-core",
+    "react-dom": "catalog:react-core",
     "react-error-boundary": "^6.0.0",
     "react-router": "^7.6.3",
     "react-router-dom": "^7.6.3",
-    "swiper": "^11.2.10"
+    "swiper": "^11.2.10",
+    "@types/react": "catalog:react-core",
+    "@types/react-dom": "catalog:react-core"
   },
   "devDependencies": {
     "@bofit/eslint": "workspace:*",
@@ -39,7 +39,8 @@
     "eslint": "^8.44.0",
     "globals": "^16.2.0",
     "openapi-typescript": "^7.8.0",
-    "typescript": "~5.8.3",
+    "typescript": "catalog:typescript-core",
+    "@types/node": "catalog:typescript-core",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@commitlint/config-conventional": "^19.8.1",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
-    "globals": "^16.2.0",
     "lefthook": "^1.11.14",
     "prettier": "^3.6.1",
     "turbo": "^2.5.4",

--- a/package.json
+++ b/package.json
@@ -26,16 +26,10 @@
     "@commitlint/config-conventional": "^19.8.1",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
-    "@vanilla-extract/css": "^1.17.4",
-    "@vanilla-extract/sprinkles": "^1.6.5",
-    "@vanilla-extract/vite-plugin": "^5.1.0",
-    "@vitejs/plugin-react-swc": "^3.10.2",
-    "@vitejs/plugin-react": "^4.5.2",
     "globals": "^16.2.0",
     "lefthook": "^1.11.14",
     "prettier": "^3.6.1",
     "turbo": "^2.5.4",
-    "typescript": "~5.8.3",
-    "vite": "^7.0.0"
+    "typescript": "~5.8.3"
   }
 }

--- a/packages/bds-ui/package.json
+++ b/packages/bds-ui/package.json
@@ -30,16 +30,16 @@
     "@types/node": "^20.11.24",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.0.1",
-    "@vanilla-extract/css": "*",
-    "@vanilla-extract/recipes": "^0.5.7",
-    "@vanilla-extract/sprinkles": "*",
-    "@vanilla-extract/vite-plugin": "*",
-    "@vitejs/plugin-react": "*",
+    "@vanilla-extract/css": "catalog:vanilla-extract-core",
+    "@vanilla-extract/recipes": "catalog:vanilla-extract-core",
+    "@vanilla-extract/sprinkles": "catalog:vanilla-extract-utils",
+    "@vanilla-extract/vite-plugin": "catalog:vanilla-extract-utils",
+    "vite": "catalog:vite-core",
+    "@vitejs/plugin-react": "catalog:vite-plugins",
     "chromatic": "^13.1.2",
     "storybook": "8.6.14",
     "tsx": "^4.20.3",
-    "typescript": "^5.3.3",
-    "vite": "*"
+    "typescript": "^5.3.3"
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/packages/bds-ui/package.json
+++ b/packages/bds-ui/package.json
@@ -27,22 +27,22 @@
     "@storybook/react": "8.6.14",
     "@storybook/react-vite": "8.6.14",
     "@turbo/gen": "^1.12.4",
-    "@types/node": "^20.11.24",
-    "@types/react": "^19.1.8",
-    "@types/react-dom": "^19.0.1",
+    "@types/node": "catalog:typescript-core",
+    "@types/react": "catalog:react-core",
+    "@types/react-dom": "catalog:react-core",
     "@vanilla-extract/css": "catalog:vanilla-extract-core",
     "@vanilla-extract/recipes": "catalog:vanilla-extract-core",
     "@vanilla-extract/sprinkles": "catalog:vanilla-extract-utils",
     "@vanilla-extract/vite-plugin": "catalog:vanilla-extract-utils",
     "vite": "catalog:vite-core",
     "@vitejs/plugin-react": "catalog:vite-plugins",
+    "typescript": "catalog:typescript-core",
     "chromatic": "^13.1.2",
     "storybook": "8.6.14",
-    "tsx": "^4.20.3",
-    "typescript": "^5.3.3"
+    "tsx": "^4.20.3"
   },
   "dependencies": {
-    "react": "^19.1.0",
-    "react-dom": "^19.0.0"
+    "react": "catalog:react-core",
+    "react-dom": "catalog:react-core"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,30 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  vanilla-extract-core:
+    '@vanilla-extract/css':
+      specifier: ^1.17.4
+      version: 1.17.4
+    '@vanilla-extract/recipes':
+      specifier: ^0.5.7
+      version: 0.5.7
+  vanilla-extract-utils:
+    '@vanilla-extract/sprinkles':
+      specifier: ^1.6.5
+      version: 1.6.5
+    '@vanilla-extract/vite-plugin':
+      specifier: ^5.1.0
+      version: 5.1.0
+  vite-core:
+    vite:
+      specifier: ^7.0.0
+      version: 7.0.5
+  vite-plugins:
+    '@vitejs/plugin-react':
+      specifier: ^4.5.2
+      version: 4.7.0
+
 importers:
   .:
     dependencies:
@@ -29,21 +53,6 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.6
         version: 19.1.6(@types/react@19.1.8)
-      '@vanilla-extract/css':
-        specifier: ^1.17.4
-        version: 1.17.4
-      '@vanilla-extract/sprinkles':
-        specifier: ^1.6.5
-        version: 1.6.5(@vanilla-extract/css@1.17.4)
-      '@vanilla-extract/vite-plugin':
-        specifier: ^5.1.0
-        version: 5.1.0(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3)(vite@7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3))
-      '@vitejs/plugin-react':
-        specifier: ^4.5.2
-        version: 4.7.0(vite@7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3))
-      '@vitejs/plugin-react-swc':
-        specifier: ^3.10.2
-        version: 3.11.0(vite@7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3))
       globals:
         specifier: ^16.2.0
         version: 16.3.0
@@ -59,9 +68,6 @@ importers:
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
-      vite:
-        specifier: ^7.0.0
-        version: 7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3)
 
   apps/client:
     dependencies:
@@ -121,19 +127,19 @@ importers:
         specifier: ^5.59.0
         version: 5.62.0(eslint@8.57.1)(typescript@5.8.3)
       '@vanilla-extract/css':
-        specifier: '*'
+        specifier: catalog:vanilla-extract-core
         version: 1.17.4
       '@vanilla-extract/recipes':
-        specifier: ^0.5.7
+        specifier: catalog:vanilla-extract-core
         version: 0.5.7(@vanilla-extract/css@1.17.4)
       '@vanilla-extract/sprinkles':
-        specifier: '*'
+        specifier: catalog:vanilla-extract-utils
         version: 1.6.5(@vanilla-extract/css@1.17.4)
       '@vanilla-extract/vite-plugin':
-        specifier: '*'
+        specifier: catalog:vanilla-extract-utils
         version: 5.1.0(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3)(vite@7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3))
       '@vitejs/plugin-react':
-        specifier: '*'
+        specifier: catalog:vite-plugins
         version: 4.7.0(vite@7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3))
       eslint:
         specifier: ^8.44.0
@@ -148,7 +154,7 @@ importers:
         specifier: ~5.8.3
         version: 5.8.3
       vite:
-        specifier: '*'
+        specifier: catalog:vite-core
         version: 7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3)
       vite-tsconfig-paths:
         specifier: ^5.1.4
@@ -250,19 +256,19 @@ importers:
         specifier: ^19.0.1
         version: 19.1.6(@types/react@19.1.8)
       '@vanilla-extract/css':
-        specifier: '*'
+        specifier: catalog:vanilla-extract-core
         version: 1.17.4
       '@vanilla-extract/recipes':
-        specifier: ^0.5.7
+        specifier: catalog:vanilla-extract-core
         version: 0.5.7(@vanilla-extract/css@1.17.4)
       '@vanilla-extract/sprinkles':
-        specifier: '*'
+        specifier: catalog:vanilla-extract-utils
         version: 1.6.5(@vanilla-extract/css@1.17.4)
       '@vanilla-extract/vite-plugin':
-        specifier: '*'
+        specifier: catalog:vanilla-extract-utils
         version: 5.1.0(@types/node@20.19.9)(jiti@2.4.2)(tsx@4.20.3)(vite@7.0.5(@types/node@20.19.9)(jiti@2.4.2)(tsx@4.20.3))
       '@vitejs/plugin-react':
-        specifier: '*'
+        specifier: catalog:vite-plugins
         version: 4.7.0(vite@7.0.5(@types/node@20.19.9)(jiti@2.4.2)(tsx@4.20.3))
       chromatic:
         specifier: ^13.1.2
@@ -277,7 +283,7 @@ importers:
         specifier: ^5.3.3
         version: 5.8.3
       vite:
-        specifier: '*'
+        specifier: catalog:vite-core
         version: 7.0.5(@types/node@20.19.9)(jiti@2.4.2)(tsx@4.20.3)
 
 packages:
@@ -1368,28 +1374,12 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.44.1':
-    resolution:
-      {
-        integrity: sha512-JAcBr1+fgqx20m7Fwe1DxPUl/hPkee6jA6Pl7n1v2EFiktAHenTaXl5aIFjUIEsfn9w3HE4gK1lEgNGMzBDs1w==,
-      }
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm-eabi@4.45.1':
     resolution:
       {
         integrity: sha512-NEySIFvMY0ZQO+utJkgoMiCAjMrGvnbDLHvcmlA33UXJpYBCvlBEbMMtV837uCkS+plG2umfhn0T5mMAxGrlRA==,
       }
     cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.44.1':
-    resolution:
-      {
-        integrity: sha512-RurZetXqTu4p+G0ChbnkwBuAtwAbIwJkycw1n6GvlGlBuS4u5qlr5opix8cBAYFJgaY05TWtM+LaoFggUmbZEQ==,
-      }
-    cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.45.1':
@@ -1400,28 +1390,12 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.44.1':
-    resolution:
-      {
-        integrity: sha512-fM/xPesi7g2M7chk37LOnmnSTHLG/v2ggWqKj3CCA1rMA4mm5KVBT1fNoswbo1JhPuNNZrVwpTvlCVggv8A2zg==,
-      }
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.45.1':
     resolution:
       {
         integrity: sha512-FSncqHvqTm3lC6Y13xncsdOYfxGSLnP+73k815EfNmpewPs+EyM49haPS105Rh4aF5mJKywk9X0ogzLXZzN9lA==,
       }
     cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.44.1':
-    resolution:
-      {
-        integrity: sha512-gDnWk57urJrkrHQ2WVx9TSVTH7lSlU7E3AFqiko+bgjlh78aJ88/3nycMax52VIVjIm3ObXnDL2H00e/xzoipw==,
-      }
-    cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.45.1':
@@ -1432,28 +1406,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.44.1':
-    resolution:
-      {
-        integrity: sha512-wnFQmJ/zPThM5zEGcnDcCJeYJgtSLjh1d//WuHzhf6zT3Md1BvvhJnWoy+HECKu2bMxaIcfWiu3bJgx6z4g2XA==,
-      }
-    cpu: [arm64]
-    os: [freebsd]
-
   '@rollup/rollup-freebsd-arm64@4.45.1':
     resolution:
       {
         integrity: sha512-4g1kaDxQItZsrkVTdYQ0bxu4ZIQ32cotoQbmsAnW1jAE4XCMbcBPDirX5fyUzdhVCKgPcrwWuucI8yrVRBw2+g==,
       }
     cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.44.1':
-    resolution:
-      {
-        integrity: sha512-uBmIxoJ4493YATvU2c0upGz87f99e3wop7TJgOA/bXMFd2SvKCI7xkxY/5k50bv7J6dw1SXT4MQBQSLn8Bb/Uw==,
-      }
-    cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.45.1':
@@ -1464,26 +1422,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.44.1':
-    resolution:
-      {
-        integrity: sha512-n0edDmSHlXFhrlmTK7XBuwKlG5MbS7yleS1cQ9nn4kIeW+dJH+ExqNgQ0RrFRew8Y+0V/x6C5IjsHrJmiHtkxQ==,
-      }
-    cpu: [arm]
-    os: [linux]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.45.1':
     resolution:
       {
         integrity: sha512-RkdOTu2jK7brlu+ZwjMIZfdV2sSYHK2qR08FUWcIoqJC2eywHbXr0L8T/pONFwkGukQqERDheaGTeedG+rra6Q==,
-      }
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.44.1':
-    resolution:
-      {
-        integrity: sha512-8WVUPy3FtAsKSpyk21kV52HCxB+me6YkbkFHATzC2Yd3yuqHwy2lbFL4alJOLXKljoRw08Zk8/xEj89cLQ/4Nw==,
       }
     cpu: [arm]
     os: [linux]
@@ -1496,26 +1438,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.44.1':
-    resolution:
-      {
-        integrity: sha512-yuktAOaeOgorWDeFJggjuCkMGeITfqvPgkIXhDqsfKX8J3jGyxdDZgBV/2kj/2DyPaLiX6bPdjJDTu9RB8lUPQ==,
-      }
-    cpu: [arm64]
-    os: [linux]
-
   '@rollup/rollup-linux-arm64-gnu@4.45.1':
     resolution:
       {
         integrity: sha512-k3dOKCfIVixWjG7OXTCOmDfJj3vbdhN0QYEqB+OuGArOChek22hn7Uy5A/gTDNAcCy5v2YcXRJ/Qcnm4/ma1xw==,
-      }
-    cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-musl@4.44.1':
-    resolution:
-      {
-        integrity: sha512-W+GBM4ifET1Plw8pdVaecwUgxmiH23CfAUj32u8knq0JPFyK4weRy6H7ooxYFD19YxBulL0Ktsflg5XS7+7u9g==,
       }
     cpu: [arm64]
     os: [linux]
@@ -1528,28 +1454,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.44.1':
-    resolution:
-      {
-        integrity: sha512-1zqnUEMWp9WrGVuVak6jWTl4fEtrVKfZY7CvcBmUUpxAJ7WcSowPSAWIKa/0o5mBL/Ij50SIf9tuirGx63Ovew==,
-      }
-    cpu: [loong64]
-    os: [linux]
-
   '@rollup/rollup-linux-loongarch64-gnu@4.45.1':
     resolution:
       {
         integrity: sha512-9UmI0VzGmNJ28ibHW2GpE2nF0PBQqsyiS4kcJ5vK+wuwGnV5RlqdczVocDSUfGX/Na7/XINRVoUgJyFIgipoRg==,
       }
     cpu: [loong64]
-    os: [linux]
-
-  '@rollup/rollup-linux-powerpc64le-gnu@4.44.1':
-    resolution:
-      {
-        integrity: sha512-Rl3JKaRu0LHIx7ExBAAnf0JcOQetQffaw34T8vLlg9b1IhzcBgaIdnvEbbsZq9uZp3uAH+JkHd20Nwn0h9zPjA==,
-      }
-    cpu: [ppc64]
     os: [linux]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.45.1':
@@ -1560,26 +1470,10 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.44.1':
-    resolution:
-      {
-        integrity: sha512-j5akelU3snyL6K3N/iX7otLBIl347fGwmd95U5gS/7z6T4ftK288jKq3A5lcFKcx7wwzb5rgNvAg3ZbV4BqUSw==,
-      }
-    cpu: [riscv64]
-    os: [linux]
-
   '@rollup/rollup-linux-riscv64-gnu@4.45.1':
     resolution:
       {
         integrity: sha512-nlcl3jgUultKROfZijKjRQLUu9Ma0PeNv/VFHkZiKbXTBQXhpytS8CIj5/NfBeECZtY2FJQubm6ltIxm/ftxpw==,
-      }
-    cpu: [riscv64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-musl@4.44.1':
-    resolution:
-      {
-        integrity: sha512-ppn5llVGgrZw7yxbIm8TTvtj1EoPgYUAbfw0uDjIOzzoqlZlZrLJ/KuiE7uf5EpTpCTrNt1EdtzF0naMm0wGYg==,
       }
     cpu: [riscv64]
     os: [linux]
@@ -1592,14 +1486,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.44.1':
-    resolution:
-      {
-        integrity: sha512-Hu6hEdix0oxtUma99jSP7xbvjkUM/ycke/AQQ4EC5g7jNRLLIwjcNwaUy95ZKBJJwg1ZowsclNnjYqzN4zwkAw==,
-      }
-    cpu: [s390x]
-    os: [linux]
-
   '@rollup/rollup-linux-s390x-gnu@4.45.1':
     resolution:
       {
@@ -1608,26 +1494,10 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.44.1':
-    resolution:
-      {
-        integrity: sha512-EtnsrmZGomz9WxK1bR5079zee3+7a+AdFlghyd6VbAjgRJDbTANJ9dcPIPAi76uG05micpEL+gPGmAKYTschQw==,
-      }
-    cpu: [x64]
-    os: [linux]
-
   '@rollup/rollup-linux-x64-gnu@4.45.1':
     resolution:
       {
         integrity: sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==,
-      }
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-musl@4.44.1':
-    resolution:
-      {
-        integrity: sha512-iAS4p+J1az6Usn0f8xhgL4PaU878KEtutP4hqw52I4IO6AGoyOkHCxcc4bqufv1tQLdDWFx8lR9YlwxKuv3/3g==,
       }
     cpu: [x64]
     os: [linux]
@@ -1640,14 +1510,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.44.1':
-    resolution:
-      {
-        integrity: sha512-NtSJVKcXwcqozOl+FwI41OH3OApDyLk3kqTJgx8+gp6On9ZEt5mYhIsKNPGuaZr3p9T6NWPKGU/03Vw4CNU9qg==,
-      }
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.45.1':
     resolution:
       {
@@ -1656,28 +1518,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.44.1':
-    resolution:
-      {
-        integrity: sha512-JYA3qvCOLXSsnTR3oiyGws1Dm0YTuxAAeaYGVlGpUsHqloPcFjPg+X0Fj2qODGLNwQOAcCiQmHub/V007kiH5A==,
-      }
-    cpu: [ia32]
-    os: [win32]
-
   '@rollup/rollup-win32-ia32-msvc@4.45.1':
     resolution:
       {
         integrity: sha512-lxV2Pako3ujjuUe9jiU3/s7KSrDfH6IgTSQOnDWr9aJ92YsFd7EurmClK0ly/t8dzMkDtd04g60WX6yl0sGfdw==,
       }
     cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.44.1':
-    resolution:
-      {
-        integrity: sha512-J8o22LuF0kTe7m+8PvW9wk3/bRq5+mRo5Dqo6+vXb7otCm3TPhYOJqOaQtGU9YMWQSL3krMnoOxMr0+9E6F3Ug==,
-      }
-    cpu: [x64]
     os: [win32]
 
   '@rollup/rollup-win32-x64-msvc@4.45.1':
@@ -2441,14 +2287,6 @@ packages:
       }
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0
-
-  '@vitejs/plugin-react-swc@3.11.0':
-    resolution:
-      {
-        integrity: sha512-YTJCGFdNMHCMfjODYtxRNVAYmTWQ1Lb8PulP/2/f/oEEtglw8oKxKIZmmRkyXrVrHfsKOaVkAc3NT9/dMutO5w==,
-      }
-    peerDependencies:
-      vite: ^4 || ^5 || ^6 || ^7
 
   '@vitejs/plugin-react@4.7.0':
     resolution:
@@ -6049,14 +5887,6 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  rollup@4.44.1:
-    resolution:
-      {
-        integrity: sha512-x8H8aPvD+xbl0Do8oez5f5o8eMS3trfCghc4HhLAnCkj7Vl0d1JWGs0UF/D886zLW2rOj2QymV/JcSSsw+XDNg==,
-      }
-    engines: { node: '>=18.0.0', npm: '>=8.0.0' }
-    hasBin: true
-
   rollup@4.45.1:
     resolution:
       {
@@ -7222,7 +7052,7 @@ snapshots:
       '@babel/parser': 7.28.0
       '@babel/template': 7.27.2
       '@babel/traverse': 7.28.0
-      '@babel/types': 7.28.0
+      '@babel/types': 7.28.1
       convert-source-map: 2.0.0
       debug: 4.4.1(supports-color@10.0.0)
       gensync: 1.0.0-beta.2
@@ -7252,7 +7082,7 @@ snapshots:
   '@babel/helper-module-imports@7.27.1':
     dependencies:
       '@babel/traverse': 7.28.0
-      '@babel/types': 7.28.0
+      '@babel/types': 7.28.1
     transitivePeerDependencies:
       - supports-color
 
@@ -7276,7 +7106,7 @@ snapshots:
   '@babel/helpers@7.27.6':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.0
+      '@babel/types': 7.28.1
 
   '@babel/parser@7.28.0':
     dependencies:
@@ -7900,121 +7730,61 @@ snapshots:
     optionalDependencies:
       rollup: 4.45.1
 
-  '@rollup/rollup-android-arm-eabi@4.44.1':
-    optional: true
-
   '@rollup/rollup-android-arm-eabi@4.45.1':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.44.1':
     optional: true
 
   '@rollup/rollup-android-arm64@4.45.1':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.44.1':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.45.1':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.44.1':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.45.1':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.44.1':
-    optional: true
-
   '@rollup/rollup-freebsd-arm64@4.45.1':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.44.1':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.45.1':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.44.1':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.45.1':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.44.1':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.45.1':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.44.1':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.45.1':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.44.1':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.45.1':
     optional: true
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.44.1':
-    optional: true
-
   '@rollup/rollup-linux-loongarch64-gnu@4.45.1':
-    optional: true
-
-  '@rollup/rollup-linux-powerpc64le-gnu@4.44.1':
     optional: true
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.45.1':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.44.1':
-    optional: true
-
   '@rollup/rollup-linux-riscv64-gnu@4.45.1':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.44.1':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.45.1':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.44.1':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.45.1':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.44.1':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.45.1':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.44.1':
-    optional: true
-
   '@rollup/rollup-linux-x64-musl@4.45.1':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.44.1':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.45.1':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.44.1':
-    optional: true
-
   '@rollup/rollup-win32-ia32-msvc@4.45.1':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.44.1':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.45.1':
@@ -8290,12 +8060,15 @@ snapshots:
       '@swc/core-win32-arm64-msvc': 1.13.2
       '@swc/core-win32-ia32-msvc': 1.13.2
       '@swc/core-win32-x64-msvc': 1.13.2
+    optional: true
 
-  '@swc/counter@0.1.3': {}
+  '@swc/counter@0.1.3':
+    optional: true
 
   '@swc/types@0.1.23':
     dependencies:
       '@swc/counter': 0.1.3
+    optional: true
 
   '@tanstack/query-core@5.83.0': {}
 
@@ -8621,7 +8394,7 @@ snapshots:
       '@vanilla-extract/babel-plugin-debug-ids': 1.2.2
       '@vanilla-extract/css': 1.17.4
       dedent: 1.6.0
-      esbuild: 0.25.5
+      esbuild: 0.25.8
       eval: 0.1.8
       find-up: 5.0.0
       javascript-stringify: 2.1.0
@@ -8679,14 +8452,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-
-  '@vitejs/plugin-react-swc@3.11.0(vite@7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.0-beta.27
-      '@swc/core': 1.13.2
-      vite: 7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3)
-    transitivePeerDependencies:
-      - '@swc/helpers'
 
   '@vitejs/plugin-react@4.7.0(vite@7.0.5(@types/node@20.19.9)(jiti@2.4.2)(tsx@4.20.3))':
     dependencies:
@@ -10980,32 +10745,6 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rollup@4.44.1:
-    dependencies:
-      '@types/estree': 1.0.8
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.44.1
-      '@rollup/rollup-android-arm64': 4.44.1
-      '@rollup/rollup-darwin-arm64': 4.44.1
-      '@rollup/rollup-darwin-x64': 4.44.1
-      '@rollup/rollup-freebsd-arm64': 4.44.1
-      '@rollup/rollup-freebsd-x64': 4.44.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.44.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.44.1
-      '@rollup/rollup-linux-arm64-gnu': 4.44.1
-      '@rollup/rollup-linux-arm64-musl': 4.44.1
-      '@rollup/rollup-linux-loongarch64-gnu': 4.44.1
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.44.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.44.1
-      '@rollup/rollup-linux-riscv64-musl': 4.44.1
-      '@rollup/rollup-linux-s390x-gnu': 4.44.1
-      '@rollup/rollup-linux-x64-gnu': 4.44.1
-      '@rollup/rollup-linux-x64-musl': 4.44.1
-      '@rollup/rollup-win32-arm64-msvc': 4.44.1
-      '@rollup/rollup-win32-ia32-msvc': 4.44.1
-      '@rollup/rollup-win32-x64-msvc': 4.44.1
-      fsevents: 2.3.3
-
   rollup@4.45.1:
     dependencies:
       '@types/estree': 1.0.8
@@ -11031,7 +10770,6 @@ snapshots:
       '@rollup/rollup-win32-ia32-msvc': 4.45.1
       '@rollup/rollup-win32-x64-msvc': 4.45.1
       fsevents: 2.3.3
-    optional: true
 
   run-async@2.4.1: {}
 
@@ -11597,11 +11335,11 @@ snapshots:
 
   vite@6.3.5(@types/node@20.19.9)(jiti@2.4.2)(tsx@4.20.3):
     dependencies:
-      esbuild: 0.25.5
+      esbuild: 0.25.8
       fdir: 6.4.6(picomatch@4.0.2)
       picomatch: 4.0.2
       postcss: 8.5.6
-      rollup: 4.44.1
+      rollup: 4.45.1
       tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 20.19.9
@@ -11611,11 +11349,11 @@ snapshots:
 
   vite@6.3.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3):
     dependencies:
-      esbuild: 0.25.5
+      esbuild: 0.25.8
       fdir: 6.4.6(picomatch@4.0.2)
       picomatch: 4.0.2
       postcss: 8.5.6
-      rollup: 4.44.1
+      rollup: 4.45.1
       tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 24.1.0
@@ -11625,11 +11363,11 @@ snapshots:
 
   vite@7.0.5(@types/node@20.19.9)(jiti@2.4.2)(tsx@4.20.3):
     dependencies:
-      esbuild: 0.25.5
+      esbuild: 0.25.8
       fdir: 6.4.6(picomatch@4.0.2)
       picomatch: 4.0.2
       postcss: 8.5.6
-      rollup: 4.44.1
+      rollup: 4.45.1
       tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 20.19.9
@@ -11639,11 +11377,11 @@ snapshots:
 
   vite@7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3):
     dependencies:
-      esbuild: 0.25.5
+      esbuild: 0.25.8
       fdir: 6.4.6(picomatch@4.0.2)
       picomatch: 4.0.2
       postcss: 8.5.6
-      rollup: 4.44.1
+      rollup: 4.45.1
       tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 24.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,9 +53,6 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.6
         version: 19.1.6(@types/react@19.1.8)
-      globals:
-        specifier: ^16.2.0
-        version: 16.3.0
       lefthook:
         specifier: ^1.11.14
         version: 1.12.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,26 @@ settings:
   excludeLinksFromLockfile: false
 
 catalogs:
+  react-core:
+    '@types/react':
+      specifier: ^19.1.8
+      version: 19.1.8
+    '@types/react-dom':
+      specifier: ^19.0.1
+      version: 19.1.6
+    react:
+      specifier: ^19.1.0
+      version: 19.1.0
+    react-dom:
+      specifier: ^19.1.0
+      version: 19.1.0
+  typescript-core:
+    '@types/node':
+      specifier: ^20.11.24
+      version: 20.19.9
+    typescript:
+      specifier: ~5.8.3
+      version: 5.8.3
   vanilla-extract-core:
     '@vanilla-extract/css':
       specifier: ^1.17.4
@@ -81,19 +101,19 @@ importers:
         specifier: ^1.2.1
         version: 1.2.1
       '@types/react':
-        specifier: ^19.1.8
+        specifier: catalog:react-core
         version: 19.1.8
       '@types/react-dom':
-        specifier: ^19.1.6
+        specifier: catalog:react-core
         version: 19.1.6(@types/react@19.1.8)
       lottie-react:
         specifier: ^2.4.1
         version: 2.4.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
-        specifier: ^19.1.0
+        specifier: catalog:react-core
         version: 19.1.0
       react-dom:
-        specifier: ^19.1.0
+        specifier: catalog:react-core
         version: 19.1.0(react@19.1.0)
       react-error-boundary:
         specifier: ^6.0.0
@@ -116,7 +136,10 @@ importers:
         version: link:../../config/typescript
       '@pivanov/vite-plugin-svg-sprite':
         specifier: ^3.0.0
-        version: 3.1.2(vite@7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3))
+        version: 3.1.2(vite@7.0.5(@types/node@20.19.9)(jiti@2.4.2)(tsx@4.20.3))
+      '@types/node':
+        specifier: catalog:typescript-core
+        version: 20.19.9
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.59.0
         version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
@@ -134,10 +157,10 @@ importers:
         version: 1.6.5(@vanilla-extract/css@1.17.4)
       '@vanilla-extract/vite-plugin':
         specifier: catalog:vanilla-extract-utils
-        version: 5.1.0(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3)(vite@7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3))
+        version: 5.1.0(@types/node@20.19.9)(jiti@2.4.2)(tsx@4.20.3)(vite@7.0.5(@types/node@20.19.9)(jiti@2.4.2)(tsx@4.20.3))
       '@vitejs/plugin-react':
         specifier: catalog:vite-plugins
-        version: 4.7.0(vite@7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3))
+        version: 4.7.0(vite@7.0.5(@types/node@20.19.9)(jiti@2.4.2)(tsx@4.20.3))
       eslint:
         specifier: ^8.44.0
         version: 8.57.1
@@ -148,14 +171,14 @@ importers:
         specifier: ^7.8.0
         version: 7.8.0(typescript@5.8.3)
       typescript:
-        specifier: ~5.8.3
+        specifier: catalog:typescript-core
         version: 5.8.3
       vite:
         specifier: catalog:vite-core
-        version: 7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3)
+        version: 7.0.5(@types/node@20.19.9)(jiti@2.4.2)(tsx@4.20.3)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.8.3)(vite@7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3))
+        version: 5.1.4(typescript@5.8.3)(vite@7.0.5(@types/node@20.19.9)(jiti@2.4.2)(tsx@4.20.3))
 
   config/eslint:
     devDependencies:
@@ -201,10 +224,10 @@ importers:
   packages/bds-ui:
     dependencies:
       react:
-        specifier: ^19.1.0
+        specifier: catalog:react-core
         version: 19.1.0
       react-dom:
-        specifier: ^19.0.0
+        specifier: catalog:react-core
         version: 19.1.0(react@19.1.0)
     devDependencies:
       '@bofit/eslint':
@@ -244,13 +267,13 @@ importers:
         specifier: ^1.12.4
         version: 1.13.4(@swc/core@1.13.2)(@types/node@20.19.9)(typescript@5.8.3)
       '@types/node':
-        specifier: ^20.11.24
+        specifier: catalog:typescript-core
         version: 20.19.9
       '@types/react':
-        specifier: ^19.1.8
+        specifier: catalog:react-core
         version: 19.1.8
       '@types/react-dom':
-        specifier: ^19.0.1
+        specifier: catalog:react-core
         version: 19.1.6(@types/react@19.1.8)
       '@vanilla-extract/css':
         specifier: catalog:vanilla-extract-core
@@ -277,7 +300,7 @@ importers:
         specifier: ^4.20.3
         version: 4.20.3
       typescript:
-        specifier: ^5.3.3
+        specifier: catalog:typescript-core
         version: 5.8.3
       vite:
         specifier: catalog:vite-core
@@ -7682,13 +7705,6 @@ snapshots:
       svgo: 4.0.0
       vite: 7.0.5(@types/node@20.19.9)(jiti@2.4.2)(tsx@4.20.3)
 
-  '@pivanov/vite-plugin-svg-sprite@3.1.2(vite@7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3))':
-    dependencies:
-      cheerio: 1.1.0
-      chokidar: 4.0.3
-      svgo: 4.0.0
-      vite: 7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3)
-
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -8179,7 +8195,7 @@ snapshots:
 
   '@types/conventional-commits-parser@5.0.1':
     dependencies:
-      '@types/node': 20.19.9
+      '@types/node': 24.1.0
 
   '@types/doctrine@0.0.9': {}
 
@@ -8188,7 +8204,7 @@ snapshots:
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 6.0.0
-      '@types/node': 20.19.9
+      '@types/node': 24.1.0
 
   '@types/inquirer@6.5.0':
     dependencies:
@@ -8227,7 +8243,7 @@ snapshots:
 
   '@types/through@0.0.33':
     dependencies:
-      '@types/node': 20.19.9
+      '@types/node': 24.1.0
 
   '@types/tinycolor2@1.4.6': {}
 
@@ -8346,27 +8362,6 @@ snapshots:
       - tsx
       - yaml
 
-  '@vanilla-extract/compiler@0.3.0(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3)':
-    dependencies:
-      '@vanilla-extract/css': 1.17.4
-      '@vanilla-extract/integration': 8.0.4
-      vite: 6.3.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3)
-      vite-node: 3.2.4(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   '@vanilla-extract/css@1.17.4':
     dependencies:
       '@emotion/hash': 0.9.2
@@ -8430,26 +8425,6 @@ snapshots:
       - tsx
       - yaml
 
-  '@vanilla-extract/vite-plugin@5.1.0(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3)(vite@7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3))':
-    dependencies:
-      '@vanilla-extract/compiler': 0.3.0(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3)
-      '@vanilla-extract/integration': 8.0.4
-      vite: 7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   '@vitejs/plugin-react@4.7.0(vite@7.0.5(@types/node@20.19.9)(jiti@2.4.2)(tsx@4.20.3))':
     dependencies:
       '@babel/core': 7.28.0
@@ -8459,18 +8434,6 @@ snapshots:
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
       vite: 7.0.5(@types/node@20.19.9)(jiti@2.4.2)(tsx@4.20.3)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@vitejs/plugin-react@4.7.0(vite@7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3))':
-    dependencies:
-      '@babel/core': 7.28.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.0)
-      '@rolldown/pluginutils': 1.0.0-beta.27
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.17.0
-      vite: 7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -9429,7 +9392,7 @@ snapshots:
 
   eval@0.1.8:
     dependencies:
-      '@types/node': 20.19.9
+      '@types/node': 24.1.0
       require-like: 0.1.2
 
   execa@5.1.1:
@@ -11298,34 +11261,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.1(supports-color@10.0.0)
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3)):
+  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@7.0.5(@types/node@20.19.9)(jiti@2.4.2)(tsx@4.20.3)):
     dependencies:
       debug: 4.4.1(supports-color@10.0.0)
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.8.3)
     optionalDependencies:
-      vite: 7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3)
+      vite: 7.0.5(@types/node@20.19.9)(jiti@2.4.2)(tsx@4.20.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -11344,20 +11286,6 @@ snapshots:
       jiti: 2.4.2
       tsx: 4.20.3
 
-  vite@6.3.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3):
-    dependencies:
-      esbuild: 0.25.8
-      fdir: 6.4.6(picomatch@4.0.2)
-      picomatch: 4.0.2
-      postcss: 8.5.6
-      rollup: 4.45.1
-      tinyglobby: 0.2.14
-    optionalDependencies:
-      '@types/node': 24.1.0
-      fsevents: 2.3.3
-      jiti: 2.4.2
-      tsx: 4.20.3
-
   vite@7.0.5(@types/node@20.19.9)(jiti@2.4.2)(tsx@4.20.3):
     dependencies:
       esbuild: 0.25.8
@@ -11368,20 +11296,6 @@ snapshots:
       tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 20.19.9
-      fsevents: 2.3.3
-      jiti: 2.4.2
-      tsx: 4.20.3
-
-  vite@7.0.5(@types/node@24.1.0)(jiti@2.4.2)(tsx@4.20.3):
-    dependencies:
-      esbuild: 0.25.8
-      fdir: 6.4.6(picomatch@4.0.2)
-      picomatch: 4.0.2
-      postcss: 8.5.6
-      rollup: 4.45.1
-      tinyglobby: 0.2.14
-    optionalDependencies:
-      '@types/node': 24.1.0
       fsevents: 2.3.3
       jiti: 2.4.2
       tsx: 4.20.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,3 +17,13 @@ catalogs:
 
   vite-plugins:
     '@vitejs/plugin-react': '^4.5.2'
+
+  react-core:
+    'react': '^19.1.0'
+    'react-dom': '^19.1.0'
+    '@types/react': '^19.1.8'
+    '@types/react-dom': '^19.0.1'
+
+  typescript-core:
+    typescript: ~5.8.3
+    '@types/node': ^20.11.24

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,18 @@ packages:
   - 'config/*'
   - 'apps/*'
   - 'packages/*'
+
+catalogs:
+  vanilla-extract-core:
+    '@vanilla-extract/css': '^1.17.4'
+    '@vanilla-extract/recipes': '^0.5.7'
+
+  vanilla-extract-utils:
+    '@vanilla-extract/sprinkles': '^1.6.5'
+    '@vanilla-extract/vite-plugin': '^5.1.0'
+
+  vite-core:
+    'vite': '^7.0.0'
+
+  vite-plugins:
+    '@vitejs/plugin-react': '^4.5.2'


### PR DESCRIPTION
## 📌 Summary

- #352 

## 📚 Tasks

- global package.json 공통 의존성 제거

## 👀 To Reviewer

pnpm-workspace.yaml 에 catalogs 필드를 추가해서 의존성 버전을 중앙에서 관리하도록 설정했어요. ve , vite 관련 의존성들의 버전을 catalogs 로 통일해서 중복 설치 및 버전 충돌 문제를 방어할 수 있도록 설정했어요. 

잘못해서 서로 다른 버전의 같은 라이브러리를 사용하게 되면, 런타임에서 충돌이 일어나거나 번들 크기가 커질 수 있잖아요? 카탈로그는 이런 중복과 버전 충돌 문제를 줄여주는 해결책이에요

버전 업그레이드가 필요할 때, 여러 패키지의 package.json 을 일일이 수정하지 않고 중앙에 `상수화` 해둔 pnpm-workspace.yaml 카탈로그 버전만 바꾸면 프로젝트 전체에 적용되도록 설정했어요.

ref : https://pnpm.io/catalogs

앞으로 다른 라이브러리를 공통으로 설치해야한다면 현재 pr을 레퍼런스 삼아서 설정할 수 있을 것 같아요.

<!--
## 🕶️ Requirements Checklist
- [ ]

(기능 명세서상 내용을 복사해서 테스트해주세요)
-->

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요시 .gif 형식으로 첨부해주세요.
-->
