### PR TITLE
Feat(bds): LikeButton 컴포넌트 구현

### DIFF
--- a/packages/bds-ui/src/components/index.ts
+++ b/packages/bds-ui/src/components/index.ts
@@ -6,6 +6,7 @@ export { default as Content } from './content/content';
 export { default as Floating } from './floating/floating';
 export { default as Indicator } from './indicator/indicator';
 export { default as Input } from './input/input';
+export { default as LikeButton } from './like-button/like-button';
 export { default as Modal } from './modal/modal';
 export { default as ModalContainer } from './modal/modal-container';
 export * from './modal/store/modal-store';

--- a/packages/bds-ui/src/components/like-button/like-button.css.ts
+++ b/packages/bds-ui/src/components/like-button/like-button.css.ts
@@ -8,5 +8,15 @@ export const iconVariants = recipe({
       true: { color: themeVars.color.error },
       false: { color: themeVars.color.gray600 },
     },
+    size: {
+      sm: {
+        width: '1.6rem',
+        height: '1.6rem',
+      },
+      md: {
+        width: '2.4rem',
+        height: '2.4rem',
+      },
+    },
   },
 });

--- a/packages/bds-ui/src/components/like-button/like-button.css.ts
+++ b/packages/bds-ui/src/components/like-button/like-button.css.ts
@@ -1,0 +1,12 @@
+import { recipe } from '@vanilla-extract/recipes';
+
+import { themeVars } from '../../styles';
+
+export const iconVariants = recipe({
+  variants: {
+    isActive: {
+      true: { color: themeVars.color.error },
+      false: { color: themeVars.color.gray600 },
+    },
+  },
+});

--- a/packages/bds-ui/src/components/like-button/like-button.stories.tsx
+++ b/packages/bds-ui/src/components/like-button/like-button.stories.tsx
@@ -15,45 +15,39 @@ const meta: Meta<typeof LikeButton> = {
 상태는 외부에서 관리하도록 설계하였습니다.
 
 ## 설계 고려사항
-- 이번 likebutton 컴포넌트는 접근성을 고려하여 설계하였습니다.
-- width와 height는 디자인에서 딱 정해진 값이 존재하지 않아 컴포넌트 내부에서 타입을 제한하지 않고 외부에서 자유롭게 값을 주입받을 수 있도록 하였으나 컨벤션에 따라 string 타입으로 두었습니다.
+- 접근성을 고려해 설계했습니다.
+- 크기는 \`size\` variant('sm' | 'md')로 관리합니다. sm: '1.6rem', md: '2.4rem'
 
 ## 접근성
-- \`aria-label\`은 동작(눌렀을 때의 행동)을 설명합니다. 사용자로부터 aria-label을 입력받아서 사용하도록 하였습니다.
+- \`aria-label\`은 동작(눌렀을 때의 행동)을 설명합니다. 사용자로부터 \`ariaLabelWhenActive\` / \`ariaLabelWhenInActive\`를 입력받아 사용합니다.
 
 ## Props 요약
-- **width**: 아이콘 가로 (string)
-- **height**: 아이콘 세로 (string)
+- **size**: 아이콘 크기 프리셋 ('sm' | 'md')
 - **isActive**: 현재 좋아요 상태 (boolean)
-- **onToggle?**: 클릭 시 호출되는 콜백 (상태 토글은 상위에서 처리, 맨 밑에 Interactive 부분이 있으니 여기서 테스트하시면 됩니다.)
-- **ariaLabelWhenActive?**: 활성화(좋아요됨) 상태일 때 스크린리더에 노출될 라벨내용
-- **ariaLabelWhenInActive?**: 비활성화(좋아요 안됨) 상태일 때 스크린리더에 노출될 라벨내용
+- **onToggle?**: 클릭 시 호출되는 콜백 (상태 토글은 상위에서 처리; 맨 아래 \`Interactive\`에서 테스트)
+- **ariaLabelWhenActive?**: 활성화(좋아요됨) 상태일 때 스크린리더 라벨
+- **ariaLabelWhenInActive?**: 비활성화(좋아요 안됨) 상태일 때 스크린리더 라벨
         `,
       },
     },
   },
   argTypes: {
+    size: {
+      control: { type: 'radio' },
+      options: ['sm', 'md'],
+      description: '아이콘 크기 프리셋',
+      table: { type: { summary: "'sm' | 'md'" } },
+    },
     isActive: {
       control: { type: 'boolean' },
       description: '좋아요 상태를 나타냅니다.',
       table: { type: { summary: 'boolean' } },
-    },
-    width: {
-      control: { type: 'text' },
-      description: '아이콘 가로 (px 또는 rem 등 단위 포함 문자열).',
-      table: { type: { summary: 'string' } },
-    },
-    height: {
-      control: { type: 'text' },
-      description: '아이콘 세로 (px 또는 rem 등 단위 포함 문자열).',
-      table: { type: { summary: 'string' } },
     },
     onToggle: {
       description:
         '버튼 클릭 시 호출됩니다. 상태 변경은 상위에서 처리하면 됩니다.',
       table: { type: { summary: '() => void' } },
     },
-
     ariaLabelWhenActive: {
       control: { type: 'text' },
       description: '활성화(좋아요됨) 상태에서의 aria-label.',
@@ -72,65 +66,74 @@ export default meta;
 
 type Story = StoryObj<typeof LikeButton>;
 
+// Storybook 전용 Wrapper
+function SizeWrapper({
+  size,
+  children,
+}: {
+  size: 'sm' | 'md';
+  children: React.ReactNode;
+}) {
+  const className = `sb-like-size-${size}`;
+  const css = `
+    .${className} svg {
+      width: ${size === 'sm' ? '1.6rem' : '2.4rem'} !important;
+      height: ${size === 'sm' ? '1.6rem' : '2.4rem'} !important;
+    }
+  `;
+  return (
+    <div className={className}>
+      <style>{css}</style>
+      {children}
+    </div>
+  );
+}
+
 export const Default: Story = {
   args: {
+    size: 'md',
     isActive: false,
-    width: '2.4rem',
-    height: '2.4rem',
     ariaLabelWhenActive: '좋아요 취소',
     ariaLabelWhenInActive: '좋아요',
   },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          '기본 상태입니다. 상위 컴포넌트에서 `onToggle`을 사용하여 조작합니다.',
-      },
-    },
-  },
+  render: (args) => (
+    <SizeWrapper size={args.size}>
+      <LikeButton {...args} />
+    </SizeWrapper>
+  ),
 };
 
 export const Liked: Story = {
   args: {
+    size: 'md',
     isActive: true,
-    width: '2.4rem',
-    height: '2.4rem',
     ariaLabelWhenActive: '좋아요 취소',
     ariaLabelWhenInActive: '좋아요',
   },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          '좋아요가 설정된 상태입니다. 스크린리더에서는 "좋아요 취소"로 안내됩니다.',
-      },
-    },
-  },
+  render: (args) => (
+    <SizeWrapper size={args.size}>
+      <LikeButton {...args} />
+    </SizeWrapper>
+  ),
 };
 
 export const Interactive: Story = {
   args: {
+    size: 'sm',
     isActive: false,
-    width: '3.2rem',
-    height: '3.2rem',
     ariaLabelWhenActive: '좋아요 취소',
     ariaLabelWhenInActive: '좋아요',
   },
   render: (args) => {
     const [liked, setLiked] = useState<boolean>(Boolean(args.isActive));
     return (
-      <LikeButton
-        {...args}
-        isActive={liked}
-        onToggle={() => setLiked(!liked)}
-      />
+      <SizeWrapper size={args.size}>
+        <LikeButton
+          {...args}
+          isActive={liked}
+          onToggle={() => setLiked(!liked)}
+        />
+      </SizeWrapper>
     );
-  },
-  parameters: {
-    docs: {
-      description: {
-        story: '스토리 내부에서 상태를 테스트 할 수 있도록 만들어 두었습니다.',
-      },
-    },
   },
 };

--- a/packages/bds-ui/src/components/like-button/like-button.stories.tsx
+++ b/packages/bds-ui/src/components/like-button/like-button.stories.tsx
@@ -15,26 +15,26 @@ const meta: Meta<typeof LikeButton> = {
 상태는 외부에서 관리하도록 설계하였습니다.
 
 ## 설계 고려사항
-- 이번 likebutton 컴포넌트는 접근성을 고려하며 설계하였습니다.
+- 이번 likebutton 컴포넌트는 접근성을 고려하여 설계하였습니다.
 - width와 height는 디자인에서 딱 정해진 값이 존재하지 않아 컴포넌트 내부에서 타입을 제한하지 않고 외부에서 자유롭게 값을 주입받을 수 있도록 하였습니다.
 
 ## 접근성
 - \`aria-pressed\`로 현재 토글 상태를 노출합니다.
 - \`aria-label\`은 동작(눌렀을 때의 행동)을 설명합니다.  
-  - liked=true → "좋아요 취소"  
-  - liked=false → "좋아요"
+  - isActive = true → "비어있는 좋아요"  
+  - isActive = false → "좋아요"
 
 ## Props 요약
 - **width**: 아이콘 가로 (number | string)
 - **height**: 아이콘 세로 (number | string)
-- **liked**: 현재 좋아요 상태 (boolean)
+- **isActive**: 현재 좋아요 상태 (boolean)
 - **onToggle?**: 클릭 시 호출되는 콜백 (상태 토글은 상위에서 처리, 맨 밑에 Interactive 부분이 있으니 여기서 테스트하시면 됩니다.)
         `,
       },
     },
   },
   argTypes: {
-    liked: {
+    isActive: {
       control: { type: 'boolean' },
       description: '좋아요 상태를 나타냅니다.',
       table: { type: { summary: 'boolean' } },
@@ -67,7 +67,7 @@ type Story = StoryObj<typeof LikeButton>;
  */
 export const Default: Story = {
   args: {
-    liked: false,
+    isActive: false,
     width: 24,
     height: 24,
   },
@@ -86,7 +86,7 @@ export const Default: Story = {
  */
 export const Liked: Story = {
   args: {
-    liked: true,
+    isActive: true,
     width: 24,
     height: 24,
   },
@@ -105,14 +105,18 @@ export const Liked: Story = {
  */
 export const Interactive: Story = {
   args: {
-    liked: false,
+    isActive: false,
     width: 32,
     height: 32,
   },
   render: (args) => {
-    const [liked, setLiked] = useState<boolean>(Boolean(args.liked));
+    const [liked, setLiked] = useState<boolean>(Boolean(args.isActive));
     return (
-      <LikeButton {...args} liked={liked} onToggle={() => setLiked(!liked)} />
+      <LikeButton
+        {...args}
+        isActive={liked}
+        onToggle={() => setLiked(!liked)}
+      />
     );
   },
   parameters: {

--- a/packages/bds-ui/src/components/like-button/like-button.stories.tsx
+++ b/packages/bds-ui/src/components/like-button/like-button.stories.tsx
@@ -19,16 +19,15 @@ const meta: Meta<typeof LikeButton> = {
 - width와 height는 디자인에서 딱 정해진 값이 존재하지 않아 컴포넌트 내부에서 타입을 제한하지 않고 외부에서 자유롭게 값을 주입받을 수 있도록 하였습니다.
 
 ## 접근성
-- \`aria-pressed\`로 현재 토글 상태를 노출합니다.
-- \`aria-label\`은 동작(눌렀을 때의 행동)을 설명합니다.  
-  - isActive = true → "비어있는 좋아요"  
-  - isActive = false → "좋아요"
+- \`aria-label\`은 동작(눌렀을 때의 행동)을 설명합니다. 사용자로부터 aria-label을 입력받아서 사용하도록 하였습니다.
 
 ## Props 요약
 - **width**: 아이콘 가로 (number | string)
 - **height**: 아이콘 세로 (number | string)
 - **isActive**: 현재 좋아요 상태 (boolean)
 - **onToggle?**: 클릭 시 호출되는 콜백 (상태 토글은 상위에서 처리, 맨 밑에 Interactive 부분이 있으니 여기서 테스트하시면 됩니다.)
+- **ariaLabelWhenActive?**: 활성화(좋아요됨) 상태일 때 스크린리더에 노출될 라벨내용
+- **ariaLabelWhenInActive?**: 비활성화(좋아요 안됨) 상태일 때 스크린리더에 노출될 라벨내용
         `,
       },
     },
@@ -54,6 +53,17 @@ const meta: Meta<typeof LikeButton> = {
         '버튼 클릭 시 호출됩니다. 상태 변경은 상위에서 처리하면 됩니다.',
       table: { type: { summary: '() => void' } },
     },
+
+    ariaLabelWhenActive: {
+      control: { type: 'text' },
+      description: '활성화(좋아요됨) 상태에서의 aria-label.',
+      table: { type: { summary: 'string' } },
+    },
+    ariaLabelWhenInActive: {
+      control: { type: 'text' },
+      description: '비활성(좋아요 안됨) 상태에서의 aria-label.',
+      table: { type: { summary: 'string' } },
+    },
   },
   tags: ['autodocs'],
 };
@@ -62,14 +72,13 @@ export default meta;
 
 type Story = StoryObj<typeof LikeButton>;
 
-/**
- * 기본(좋아요 해제) 상태
- */
 export const Default: Story = {
   args: {
     isActive: false,
     width: 24,
     height: 24,
+    ariaLabelWhenActive: '좋아요 취소',
+    ariaLabelWhenInActive: '좋아요',
   },
   parameters: {
     docs: {
@@ -81,14 +90,13 @@ export const Default: Story = {
   },
 };
 
-/**
- * 좋아요된 상태
- */
 export const Liked: Story = {
   args: {
     isActive: true,
     width: 24,
     height: 24,
+    ariaLabelWhenActive: '좋아요 취소',
+    ariaLabelWhenInActive: '좋아요',
   },
   parameters: {
     docs: {
@@ -100,14 +108,13 @@ export const Liked: Story = {
   },
 };
 
-/**
- * 스토리 내에서 상태를 제어하는 인터랙티브 예시
- */
 export const Interactive: Story = {
   args: {
     isActive: false,
     width: 32,
     height: 32,
+    ariaLabelWhenActive: '좋아요 취소',
+    ariaLabelWhenInActive: '좋아요',
   },
   render: (args) => {
     const [liked, setLiked] = useState<boolean>(Boolean(args.isActive));

--- a/packages/bds-ui/src/components/like-button/like-button.stories.tsx
+++ b/packages/bds-ui/src/components/like-button/like-button.stories.tsx
@@ -16,14 +16,14 @@ const meta: Meta<typeof LikeButton> = {
 
 ## 설계 고려사항
 - 이번 likebutton 컴포넌트는 접근성을 고려하여 설계하였습니다.
-- width와 height는 디자인에서 딱 정해진 값이 존재하지 않아 컴포넌트 내부에서 타입을 제한하지 않고 외부에서 자유롭게 값을 주입받을 수 있도록 하였습니다.
+- width와 height는 디자인에서 딱 정해진 값이 존재하지 않아 컴포넌트 내부에서 타입을 제한하지 않고 외부에서 자유롭게 값을 주입받을 수 있도록 하였으나 컨벤션에 따라 string 타입으로 두었습니다.
 
 ## 접근성
 - \`aria-label\`은 동작(눌렀을 때의 행동)을 설명합니다. 사용자로부터 aria-label을 입력받아서 사용하도록 하였습니다.
 
 ## Props 요약
-- **width**: 아이콘 가로 (number | string)
-- **height**: 아이콘 세로 (number | string)
+- **width**: 아이콘 가로 (string)
+- **height**: 아이콘 세로 (string)
 - **isActive**: 현재 좋아요 상태 (boolean)
 - **onToggle?**: 클릭 시 호출되는 콜백 (상태 토글은 상위에서 처리, 맨 밑에 Interactive 부분이 있으니 여기서 테스트하시면 됩니다.)
 - **ariaLabelWhenActive?**: 활성화(좋아요됨) 상태일 때 스크린리더에 노출될 라벨내용
@@ -41,12 +41,12 @@ const meta: Meta<typeof LikeButton> = {
     width: {
       control: { type: 'text' },
       description: '아이콘 가로 (px 또는 rem 등 단위 포함 문자열).',
-      table: { type: { summary: 'number | string' } },
+      table: { type: { summary: 'string' } },
     },
     height: {
       control: { type: 'text' },
       description: '아이콘 세로 (px 또는 rem 등 단위 포함 문자열).',
-      table: { type: { summary: 'number | string' } },
+      table: { type: { summary: 'string' } },
     },
     onToggle: {
       description:
@@ -75,8 +75,8 @@ type Story = StoryObj<typeof LikeButton>;
 export const Default: Story = {
   args: {
     isActive: false,
-    width: 24,
-    height: 24,
+    width: '2.4rem',
+    height: '2.4rem',
     ariaLabelWhenActive: '좋아요 취소',
     ariaLabelWhenInActive: '좋아요',
   },
@@ -93,8 +93,8 @@ export const Default: Story = {
 export const Liked: Story = {
   args: {
     isActive: true,
-    width: 24,
-    height: 24,
+    width: '2.4rem',
+    height: '2.4rem',
     ariaLabelWhenActive: '좋아요 취소',
     ariaLabelWhenInActive: '좋아요',
   },
@@ -102,7 +102,7 @@ export const Liked: Story = {
     docs: {
       description: {
         story:
-          '좋아요가 설정된 상태입니다. 스크린리더에서는 "좋아요 취소"로 안내되고, `aria-pressed`는 눌림 상태를 전달합니다.',
+          '좋아요가 설정된 상태입니다. 스크린리더에서는 "좋아요 취소"로 안내됩니다.',
       },
     },
   },
@@ -111,8 +111,8 @@ export const Liked: Story = {
 export const Interactive: Story = {
   args: {
     isActive: false,
-    width: 32,
-    height: 32,
+    width: '3.2rem',
+    height: '3.2rem',
     ariaLabelWhenActive: '좋아요 취소',
     ariaLabelWhenInActive: '좋아요',
   },
@@ -129,7 +129,7 @@ export const Interactive: Story = {
   parameters: {
     docs: {
       description: {
-        story: '스토리 내부에서 상태를 테스트 할 수 있도록 만들어 듀었습니다.',
+        story: '스토리 내부에서 상태를 테스트 할 수 있도록 만들어 두었습니다.',
       },
     },
   },

--- a/packages/bds-ui/src/components/like-button/like-button.stories.tsx
+++ b/packages/bds-ui/src/components/like-button/like-button.stories.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import LikeButton from './like-button';
+
+const meta: Meta<typeof LikeButton> = {
+  title: 'Common/LikeButton',
+  component: LikeButton,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+**LikeButton** 컴포넌트는 '좋아요' 토글을 위한 디자인 시스템 컴포넌트입니다.  
+상태는 외부에서 관리하도록 설계하였습니다.
+
+## 설계 고려사항
+- 이번 likebutton 컴포넌트는 접근성을 고려하며 설계하였습니다.
+- width와 height는 디자인에서 딱 정해진 값이 존재하지 않아 컴포넌트 내부에서 타입을 제한하지 않고 외부에서 자유롭게 값을 주입받을 수 있도록 하였습니다.
+
+## 접근성
+- \`aria-pressed\`로 현재 토글 상태를 노출합니다.
+- \`aria-label\`은 동작(눌렀을 때의 행동)을 설명합니다.  
+  - liked=true → "좋아요 취소"  
+  - liked=false → "좋아요"
+
+## Props 요약
+- **width**: 아이콘 가로 (number | string)
+- **height**: 아이콘 세로 (number | string)
+- **liked**: 현재 좋아요 상태 (boolean)
+- **onToggle?**: 클릭 시 호출되는 콜백 (상태 토글은 상위에서 처리, 맨 밑에 Interactive 부분이 있으니 여기서 테스트하시면 됩니다.)
+        `,
+      },
+    },
+  },
+  argTypes: {
+    liked: {
+      control: { type: 'boolean' },
+      description: '좋아요 상태를 나타냅니다.',
+      table: { type: { summary: 'boolean' } },
+    },
+    width: {
+      control: { type: 'text' },
+      description: '아이콘 가로 (px 또는 rem 등 단위 포함 문자열).',
+      table: { type: { summary: 'number | string' } },
+    },
+    height: {
+      control: { type: 'text' },
+      description: '아이콘 세로 (px 또는 rem 등 단위 포함 문자열).',
+      table: { type: { summary: 'number | string' } },
+    },
+    onToggle: {
+      description:
+        '버튼 클릭 시 호출됩니다. 상태 변경은 상위에서 처리하면 됩니다.',
+      table: { type: { summary: '() => void' } },
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LikeButton>;
+
+/**
+ * 기본(좋아요 해제) 상태
+ */
+export const Default: Story = {
+  args: {
+    liked: false,
+    width: 24,
+    height: 24,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '기본 상태입니다. 상위 컴포넌트에서 `onToggle`을 사용하여 조작합니다.',
+      },
+    },
+  },
+};
+
+/**
+ * 좋아요된 상태
+ */
+export const Liked: Story = {
+  args: {
+    liked: true,
+    width: 24,
+    height: 24,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '좋아요가 설정된 상태입니다. 스크린리더에서는 "좋아요 취소"로 안내되고, `aria-pressed`는 눌림 상태를 전달합니다.',
+      },
+    },
+  },
+};
+
+/**
+ * 스토리 내에서 상태를 제어하는 인터랙티브 예시
+ */
+export const Interactive: Story = {
+  args: {
+    liked: false,
+    width: 32,
+    height: 32,
+  },
+  render: (args) => {
+    const [liked, setLiked] = useState<boolean>(Boolean(args.liked));
+    return (
+      <LikeButton {...args} liked={liked} onToggle={() => setLiked(!liked)} />
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '스토리 내부에서 상태를 테스트 할 수 있도록 만들어 듀었습니다.',
+      },
+    },
+  },
+};

--- a/packages/bds-ui/src/components/like-button/like-button.tsx
+++ b/packages/bds-ui/src/components/like-button/like-button.tsx
@@ -1,12 +1,14 @@
 import { Icon } from '@bds/ui/icons';
 
+import { iconVariants } from './like-button.css';
+
 interface LikeButtonProps {
   width: number | string;
   height: number | string;
   onToggle?: () => void;
   isActive: boolean;
-  areaLabelWhenActive?: string;
-  areaLabelWhenInActive?: string;
+  ariaLabelWhenActive?: string;
+  ariaLabelWhenInActive?: string;
 }
 
 const LikeButton = ({
@@ -14,20 +16,20 @@ const LikeButton = ({
   height,
   onToggle,
   isActive,
-  areaLabelWhenActive,
-  areaLabelWhenInActive,
+  ariaLabelWhenActive,
+  ariaLabelWhenInActive,
 }: LikeButtonProps) => {
   return (
     <button
       type="button"
-      aria-label={isActive ? areaLabelWhenActive : areaLabelWhenInActive}
+      aria-label={isActive ? ariaLabelWhenActive : ariaLabelWhenInActive}
       onClick={onToggle}
     >
       <Icon
         name={isActive ? 'heart_fill' : 'heart'}
         width={width}
         height={height}
-        color={isActive ? 'error' : 'gray600'}
+        className={iconVariants({ isActive })}
       />
     </button>
   );

--- a/packages/bds-ui/src/components/like-button/like-button.tsx
+++ b/packages/bds-ui/src/components/like-button/like-button.tsx
@@ -1,32 +1,33 @@
 import { Icon } from '@bds/ui/icons';
 
-const LIKE_BUTTON_ARIA = {
-  LIKE: '좋아요',
-  UNLIKE: '비어있는 좋아요',
-};
-
 interface LikeButtonProps {
   width: number | string;
   height: number | string;
   onToggle?: () => void;
   isActive: boolean;
+  areaLabelWhenActive?: string;
+  areaLabelWhenInActive?: string;
 }
 
-const LikeButton = ({ width, height, onToggle, isActive }: LikeButtonProps) => {
-  const color = isActive ? 'error' : 'gray600';
-
+const LikeButton = ({
+  width,
+  height,
+  onToggle,
+  isActive,
+  areaLabelWhenActive,
+  areaLabelWhenInActive,
+}: LikeButtonProps) => {
   return (
     <button
       type="button"
-      aria-pressed={isActive}
-      aria-label={isActive ? LIKE_BUTTON_ARIA.UNLIKE : LIKE_BUTTON_ARIA.LIKE}
+      aria-label={isActive ? areaLabelWhenActive : areaLabelWhenInActive}
       onClick={onToggle}
     >
       <Icon
         name={isActive ? 'heart_fill' : 'heart'}
         width={width}
         height={height}
-        color={color}
+        color={isActive ? 'error' : 'gray600'}
       />
     </button>
   );

--- a/packages/bds-ui/src/components/like-button/like-button.tsx
+++ b/packages/bds-ui/src/components/like-button/like-button.tsx
@@ -3,8 +3,8 @@ import { Icon } from '@bds/ui/icons';
 import { iconVariants } from './like-button.css';
 
 interface LikeButtonProps {
-  width: number | string;
-  height: number | string;
+  width: string;
+  height: string;
   onToggle?: () => void;
   isActive: boolean;
   ariaLabelWhenActive?: string;

--- a/packages/bds-ui/src/components/like-button/like-button.tsx
+++ b/packages/bds-ui/src/components/like-button/like-button.tsx
@@ -3,8 +3,7 @@ import { Icon } from '@bds/ui/icons';
 import { iconVariants } from './like-button.css';
 
 interface LikeButtonProps {
-  width: string;
-  height: string;
+  size: 'sm' | 'md';
   onToggle?: () => void;
   isActive: boolean;
   ariaLabelWhenActive?: string;
@@ -12,8 +11,7 @@ interface LikeButtonProps {
 }
 
 const LikeButton = ({
-  width,
-  height,
+  size,
   onToggle,
   isActive,
   ariaLabelWhenActive,
@@ -27,8 +25,7 @@ const LikeButton = ({
     >
       <Icon
         name={isActive ? 'heart_fill' : 'heart'}
-        width={width}
-        height={height}
+        size={iconVariants({ size })}
         className={iconVariants({ isActive })}
       />
     </button>

--- a/packages/bds-ui/src/components/like-button/like-button.tsx
+++ b/packages/bds-ui/src/components/like-button/like-button.tsx
@@ -2,28 +2,28 @@ import { Icon } from '@bds/ui/icons';
 
 const LIKE_BUTTON_ARIA = {
   LIKE: '좋아요',
-  UNLIKE: '좋아요 취소',
+  UNLIKE: '비어있는 좋아요',
 };
 
 interface LikeButtonProps {
   width: number | string;
   height: number | string;
   onToggle?: () => void;
-  liked: boolean;
+  isActive: boolean;
 }
 
-const LikeButton = ({ width, height, onToggle, liked }: LikeButtonProps) => {
-  const color = liked ? 'error' : 'gray600';
+const LikeButton = ({ width, height, onToggle, isActive }: LikeButtonProps) => {
+  const color = isActive ? 'error' : 'gray600';
 
   return (
     <button
       type="button"
-      aria-pressed={liked}
-      aria-label={liked ? LIKE_BUTTON_ARIA.UNLIKE : LIKE_BUTTON_ARIA.LIKE}
+      aria-pressed={isActive}
+      aria-label={isActive ? LIKE_BUTTON_ARIA.UNLIKE : LIKE_BUTTON_ARIA.LIKE}
       onClick={onToggle}
     >
       <Icon
-        name={liked ? 'heart_fill' : 'heart'}
+        name={isActive ? 'heart_fill' : 'heart'}
         width={width}
         height={height}
         color={color}

--- a/packages/bds-ui/src/components/like-button/like-button.tsx
+++ b/packages/bds-ui/src/components/like-button/like-button.tsx
@@ -1,0 +1,35 @@
+import { Icon } from '@bds/ui/icons';
+
+const LIKE_BUTTON_ARIA = {
+  LIKE: '좋아요',
+  UNLIKE: '좋아요 취소',
+};
+
+interface LikeButtonProps {
+  width: number | string;
+  height: number | string;
+  onToggle?: () => void;
+  liked: boolean;
+}
+
+const LikeButton = ({ width, height, onToggle, liked }: LikeButtonProps) => {
+  const color = liked ? 'error' : 'gray600';
+
+  return (
+    <button
+      type="button"
+      aria-pressed={liked}
+      aria-label={liked ? LIKE_BUTTON_ARIA.UNLIKE : LIKE_BUTTON_ARIA.LIKE}
+      onClick={onToggle}
+    >
+      <Icon
+        name={liked ? 'heart_fill' : 'heart'}
+        width={width}
+        height={height}
+        color={color}
+      />
+    </button>
+  );
+};
+
+export default LikeButton;


### PR DESCRIPTION
## 📌 Summary

> - #371 

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._
- LikeButton 컴포넌트 구현
- LikeButton StoryBook 구현

## 📚 Tasks

- _해당 PR에 수행한 작업을 작성해주세요._
LikeButton 컴포넌트를 구현하였습니다.

```tsx
interface LikeButtonProps {
  size: 'sm' | 'md';
  onToggle?: () => void;
  isActive: boolean;
  ariaLabelWhenActive?: string;
  ariaLabelWhenInActive?: string;
}
```
~props로 width와 height를 받을 때의 타입을 number와 string으로 해둔 이유는 Icon컴포넌트도 rem단위와 number 두개 모두 받기 때문에 타입을 하나로 지정할 필요는 없을것 같다고 생각하여 타입을 둘 다 지정하였습니다.~
-> 하나의 size로 sm, md 사이즈로 두고 `sm`일때는 `1.6rem`, `md`일때는 `2.4rem`으로 설정하였습니다. 이후 size variants가 늘어나면 width, height로 사이즈를 변경할 예정입니다.

LikeButton 컴포넌트 내부에서 상태를 관리하는건 좋지 않다고 생각이 들었어요. 그래서 onToggle로 부모에서 likeButton이 true인지 false인지 핸들링 하는 함수를 넘겨주는 방식대로 구현하였습니다.
isActive는 서버에서 좋아요 상태를 내려 받았을 때를 고려하여 설계하였습니다.
접근성을 위해 aria-label을 외부에서 주입할 수 있도록 설계하였습니다. 버튼이 눌렸을 때 아닐때를 따로 설정할 수 있도록 했습니다.


## 👀 To Reviewer
- 아이콘 사이즈가 width와 height중 하나가 없어도 width, height 모두 같은 값으로 적용되는데 (이유: `viewBox`를 가지고 있어서) props로 값을 하나만 받는게 나을까요? 일단 직관적일것 같아서 둘다 받는걸로 했어요!

- 현재 bds/ui 에 icon 하트 아이콘의 종류가 `heart ( 비어있는 하트 )`와 `heart_fill ( 꽉 찬 하트 )` 두 가지가 있는데, 처음에는 stroke/fill 조정으로 하나의 아이콘만 쓰는 쪽을 고려했습니다. 하지만 svg sprite는 한 번에 로드되므로 성능 차이는 거의 없고, 최종적으로는 `heart <-> heart_fill` 전환 방식으로 구현했습니다. 음.. 주로 어떤 방식을 사용하나요??


## 📸 Screenshot

https://github.com/user-attachments/assets/86f0c6d5-964f-40d9-800e-b56ba68f3658

