### PR TITLE
[CI/CD] changeset 배포 PR 에서 action error 이슈 해결 

### DIFF
--- a/.changeset/breezy-windows-cry.md
+++ b/.changeset/breezy-windows-cry.md
@@ -1,0 +1,6 @@
+---
+'@bofit/client': major
+'@bds/ui': minor
+---
+
+refactoring 1th

--- a/.github/workflows/version-dump.yml
+++ b/.github/workflows/version-dump.yml
@@ -34,7 +34,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm -w install
 
       - name: Check for changeset files
         run: |
@@ -47,7 +47,9 @@ jobs:
           ls -la .changeset/*.md
 
       - name: Version bump
-        run: pnpm changeset version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm -w changeset version
 
       - name: Commit and push
         run: |

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "version": "changeset version",
     "release": "pnpm build && changeset publish"
   },
-  "dependencies": {},
   "devDependencies": {
+    "@changesets/changelog-github": "^0.5.1",
     "@changesets/cli": "^2.29.5",
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ catalogs:
 importers:
   .:
     devDependencies:
+      '@changesets/changelog-github':
+        specifier: ^0.5.1
+        version: 0.5.1
       '@changesets/cli':
         specifier: ^2.29.5
         version: 2.29.5
@@ -501,6 +504,12 @@ packages:
         integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==,
       }
 
+  '@changesets/changelog-github@0.5.1':
+    resolution:
+      {
+        integrity: sha512-BVuHtF+hrhUScSoHnJwTELB4/INQxVFc+P/Qdt20BLiBFIHFJDDUaGsZw+8fQeJTRP5hJZrzpt3oZWh0G19rAQ==,
+      }
+
   '@changesets/cli@2.29.5':
     resolution:
       {
@@ -524,6 +533,12 @@ packages:
     resolution:
       {
         integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==,
+      }
+
+  '@changesets/get-github-info@0.6.0':
+    resolution:
+      {
+        integrity: sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==,
       }
 
   '@changesets/get-release-plan@4.0.13':
@@ -3103,6 +3118,12 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
+  dataloader@1.4.0:
+    resolution:
+      {
+        integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==,
+      }
+
   debug@4.4.1:
     resolution:
       {
@@ -3298,6 +3319,13 @@ packages:
         integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==,
       }
     engines: { node: '>=12' }
+
+  dotenv@8.6.0:
+    resolution:
+      {
+        integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==,
+      }
+    engines: { node: '>=10' }
 
   dunder-proto@1.0.1:
     resolution:
@@ -5172,6 +5200,18 @@ packages:
         integrity: sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==,
       }
 
+  node-fetch@2.7.0:
+    resolution:
+      {
+        integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==,
+      }
+    engines: { node: 4.x || >=6.0.0 }
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-plop@0.26.3:
     resolution:
       {
@@ -6431,6 +6471,12 @@ packages:
       }
     engines: { node: '>=8.0' }
 
+  tr46@0.0.3:
+    resolution:
+      {
+        integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==,
+      }
+
   ts-dedent@2.2.0:
     resolution:
       {
@@ -6873,6 +6919,12 @@ packages:
         integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==,
       }
 
+  webidl-conversions@3.0.1:
+    resolution:
+      {
+        integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==,
+      }
+
   webpack-virtual-modules@0.6.2:
     resolution:
       {
@@ -6892,6 +6944,12 @@ packages:
         integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==,
       }
     engines: { node: '>=18' }
+
+  whatwg-url@5.0.0:
+    resolution:
+      {
+        integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==,
+      }
 
   which-boxed-primitive@1.1.1:
     resolution:
@@ -7203,6 +7261,14 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
+  '@changesets/changelog-github@0.5.1':
+    dependencies:
+      '@changesets/get-github-info': 0.6.0
+      '@changesets/types': 6.1.0
+      dotenv: 8.6.0
+    transitivePeerDependencies:
+      - encoding
+
   '@changesets/cli@2.29.5':
     dependencies:
       '@changesets/apply-release-plan': 7.0.12
@@ -7254,6 +7320,13 @@ snapshots:
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
       semver: 7.7.2
+
+  '@changesets/get-github-info@0.6.0':
+    dependencies:
+      dataloader: 1.4.0
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   '@changesets/get-release-plan@4.0.13':
     dependencies:
@@ -8921,6 +8994,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  dataloader@1.4.0: {}
+
   debug@4.4.1(supports-color@10.0.0):
     dependencies:
       ms: 2.1.3
@@ -9023,6 +9098,8 @@ snapshots:
       is-obj: 2.0.0
 
   dotenv@16.0.3: {}
+
+  dotenv@8.6.0: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -10225,6 +10302,10 @@ snapshots:
     dependencies:
       lower-case: 1.1.4
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-plop@0.26.3:
     dependencies:
       '@babel/runtime-corejs3': 7.28.0
@@ -11045,6 +11126,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tr46@0.0.3: {}
+
   ts-dedent@2.2.0: {}
 
   ts-node@10.9.2(@swc/core@1.13.2)(@types/node@20.19.9)(typescript@5.8.3):
@@ -11297,6 +11380,8 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
+  webidl-conversions@3.0.1: {}
+
   webpack-virtual-modules@0.6.2: {}
 
   whatwg-encoding@3.1.1:
@@ -11304,6 +11389,11 @@ snapshots:
       iconv-lite: 0.6.3
 
   whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:


### PR DESCRIPTION
## 📌 Summary

> - #374 

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._




## 📚 Tasks

- _해당 PR에 수행한 작업을 작성해주세요._

다음과 같이 github action 을 세팅했습니다. 

```jsx
jobs:
  version-release:
    runs-on: ubuntu-latest
    if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'develop'

    steps:
      - name: Checkout
        uses: actions/checkout@v4
        with:
          fetch-depth: 0
          ref: ${{ github.head_ref }}

      - name: 📦 Setup pnpm
        uses: pnpm/action-setup@v4
        with:
          version: 9.12.0

      - name: ⚙️ Setup Node.js
        uses: actions/setup-node@v4
        with:
          node-version: 18
          cache: 'pnpm'

      - name: Install dependencies
        run: pnpm install

      - name: Check for changeset files
        run: |
          if [ -z "$(ls .changeset/*.md 2>/dev/null)" ]; then
            echo "❌ changeset 파일이 없습니다."
            exit 1
          fi
          
          echo "✅ changeset 파일이 있습니다:"
          ls -la .changeset/*.md

      - name: Version bump
        run: pnpm changeset version

      - name: Commit and push
        run: |
          git config user.name "github-actions[bot]"
          git config user.email "github-actions[bot]@users.noreply.github.com"
          git add .
          git commit -m "chore: release version" || echo "No changes to commit"
          git push origin HEAD:${{ github.head_ref }}
```


요거는 이제 changeset 파일을 찾아서 그 파일이 없으면 에러를 뱉고, 있으면 있다고 체크를 날립니다. 

그리고 깃헙 액션을 이름으로 pnpm changeset version  명령어를 수행한 후, 

changeset 파일 기반으로 버전 세팅이 되면 그 파일들을 모두 커밋하는 명령어 입니다. 

그래서 배포 버전 세팅을 위한 changeset 파일을 생성하는 Version control 피알을 올리고 난 후, develop → main 배포 PR 에서 해당 깃헙 액션이 돌아가는지 확인했는데 다음과 같은 에러를 마주했습니다.



<img width="1517" height="565" alt="스크린샷 2025-09-08 01 32 48" src="https://github.com/user-attachments/assets/20a20d65-ad41-420b-bad8-aa3a21ea2422" />


### [ 원인 ]

@changesets/changelog-github가 설치되어 있지 않다. 
changelog에 그 플러그인을 선언해 두었으니 
CI에서 pnpm changeset version이 모듈을 못 찾고 실패한다.

### [ 해결 ] 

### 1.  루트 package.json에 플러그인 추가

pnpm add -D @changesets/changelog-github
해당 명령어를 통해 package.json 에 플러그인을 추가했습니다. 

@changesets/changelog-github 패키지란? 
: Changesets가 GitHub API를 호출해 **PR/커밋 정보 기반 changelog**를 자동 생성할 때 필요한 플러그인
package.json의 "changelog": ["@changesets/changelog-github", { "repo": "team-bofit/bofit-client" }] 설정을 쓰려면, 해당 모듈이 반드시 설치되어 있어야 하기 때문에 추가했습니다. 

### 2. 워크플로에서 토큰 제공

pnpm changeset version 스텝에 env 추가했습니다. 

```
  - name: Version bump
    env:
      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    run: pnpm changeset version

```

### 3. 루트에서 실행 보장 

루트에 .changeset/가 있고 루트 package.json에 플러그인을 넣어야 한다.

```
  - name: Install dependencies
    run: pnpm -w install

  - name: Version bump
    env:
      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    run: pnpm -w changeset version

```

다음과 같이 명령어를 변경하여  **--workspace-root 옵션** 즉, mono 레포 환경에서 최상위에서 정의된 package.json 기준으로 설치하도록 명령합니다.
