### PR TITLE
Refactor(client): 로그인 api 리팩터링

### DIFF
--- a/apps/client/src/pages/login-fallback/login-fallback-page.tsx
+++ b/apps/client/src/pages/login-fallback/login-fallback-page.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { useSocialLogin } from '@widgets/login-fallback/hooks/use-social-login';
 

--- a/apps/client/src/shared/types/schema.d.ts
+++ b/apps/client/src/shared/types/schema.d.ts
@@ -56,6 +56,30 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/posts/{post-id}/likes': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * 게시글 좋아요 생성
+     * @description 유저가 커뮤니티 게시글에 좋아요를 생성합니다.
+     */
+    post: operations['createPostLike'];
+    /**
+     * 게시글 좋아요 삭제
+     * @description 유저가 커뮤니티 게시글에 생성했던 좋아요를 삭제합니다.
+     */
+    delete: operations['deletePostLike'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/posts/{post-id}/comments': {
     parameters: {
       query?: never;
@@ -97,6 +121,47 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/oauth/kakao/logout': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** 로그아웃 */
+    post: operations['logout'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/oauth/kakao/login': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * 카카오 로그인
+     * @description 카카오 API를 통해 로그인합니다.
+     */
+    get: operations['kakaoCallback_1'];
+    put?: never;
+    /**
+     * 카카오 로그인 - POST
+     * @description 카카오 API를 통해 로그인합니다. POST 요청을 사용하여 Body에 필요한 데이터를 받아옵니다.
+     */
+    post: operations['kakaoCallback'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/insurances/reports': {
     parameters: {
       query?: never;
@@ -111,6 +176,26 @@ export interface paths {
      * @description 보험 상품을 추천 받습니다.
      */
     post: operations['issueReport'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/files/upload': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * 이미지 업로드 API
+     * @description mediaType을 통해 PresignedUrl을 발급받습니다.
+     */
+    post: operations['createdUrls'];
     delete?: never;
     options?: never;
     head?: never;
@@ -249,26 +334,6 @@ export interface paths {
      * @description 선택 가능한 보장 상황 목록을 조회합니다.
      */
     get: operations['getCoverageSelect'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/oauth/kakao/login': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * 카카오 로그인
-     * @description 카카오 API를 통해 로그인합니다.
-     */
-    get: operations['kakaoCallback'];
     put?: never;
     post?: never;
     delete?: never;
@@ -449,6 +514,15 @@ export interface components {
        */
       postId?: number;
     };
+    BaseResponseVoid: {
+      /**
+       * Format: int32
+       * @example 200
+       */
+      code?: number;
+      message?: string;
+      data?: Record<string, never>;
+    };
     CommentCreateRequest: {
       /**
        * @description 댓글 내용
@@ -466,6 +540,40 @@ export interface components {
       data?: components['schemas']['TokenReissueResponse'];
     };
     TokenReissueResponse: {
+      /** @description 액세스 토큰 */
+      accessToken?: string;
+      /** @description 리프레쉬 토큰 */
+      refreshToken?: string;
+    };
+    BaseResponseString: {
+      /**
+       * Format: int32
+       * @example 200
+       */
+      code?: number;
+      message?: string;
+      data?: string;
+    };
+    OAuthLoginRequest: {
+      code: string;
+      redirectUrl?: string;
+    };
+    BaseResponseKaKaoLoginResponse: {
+      /**
+       * Format: int32
+       * @example 200
+       */
+      code?: number;
+      message?: string;
+      data?: components['schemas']['KaKaoLoginResponse'];
+    };
+    KaKaoLoginResponse: {
+      /**
+       * Format: int64
+       * @description 유저 PK
+       * @example 1
+       */
+      userId?: number;
       /** @description 액세스 토큰 */
       accessToken?: string;
       /** @description 리프레쉬 토큰 */
@@ -592,6 +700,22 @@ export interface components {
     IssueInsuranceReportResponse: {
       /** Format: uuid */
       insuranceReportId?: string;
+    };
+    PresignedUrlRequest: {
+      /** @description 파일 형식 */
+      mediaType?: string[];
+    };
+    BaseResponsePresignedUrlResponse: {
+      /**
+       * Format: int32
+       * @example 200
+       */
+      code?: number;
+      message?: string;
+      data?: components['schemas']['PresignedUrlResponse'];
+    };
+    PresignedUrlResponse: {
+      presignedUrls?: string[];
     };
     BaseResponseInsuranceReportSummaryResponse: {
       /**
@@ -972,27 +1096,6 @@ export interface components {
       /** @description 마지막 페이지 여부 */
       isLast?: boolean;
     };
-    BaseResponseKaKaoLoginResponse: {
-      /**
-       * Format: int32
-       * @example 200
-       */
-      code?: number;
-      message?: string;
-      data?: components['schemas']['KaKaoLoginResponse'];
-    };
-    KaKaoLoginResponse: {
-      /**
-       * Format: int64
-       * @description 유저 PK
-       * @example 1
-       */
-      userId?: number;
-      /** @description 액세스 토큰 */
-      accessToken?: string;
-      /** @description 리프레쉬 토큰 */
-      refreshToken?: string;
-    };
     BaseResponseInsuranceReportResponse: {
       /**
        * Format: int32
@@ -1035,7 +1138,13 @@ export interface components {
     };
     SectionData: {
       additionalInfo?: string;
-      statuses?: components['schemas']['ShowCoverageStatus'][];
+      resource?: string;
+      statuses?: components['schemas']['ShowCoverageStatusDetail'][];
+    };
+    ShowCoverageStatusDetail: {
+      target?: string;
+      status?: string;
+      queryParamValue?: string;
     };
     BaseResponseSurgerySection: {
       /**
@@ -1126,15 +1235,6 @@ export interface components {
       displayName?: string;
       hyphenCase?: string;
       coverage?: components['schemas']['CompareCoverage'];
-    };
-    BaseResponseVoid: {
-      /**
-       * Format: int32
-       * @example 200
-       */
-      code?: number;
-      message?: string;
-      data?: Record<string, never>;
     };
   };
   responses: never;
@@ -1508,6 +1608,154 @@ export interface operations {
       };
     };
   };
+  createPostLike: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        'post-id': number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponseVoid'];
+        };
+      };
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      405: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+    };
+  };
+  deletePostLike: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        'post-id': number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponseVoid'];
+        };
+      };
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      405: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+    };
+  };
   getComments: {
     parameters: {
       query?: {
@@ -1731,6 +1979,225 @@ export interface operations {
       };
     };
   };
+  logout: {
+    parameters: {
+      query?: {
+        'redirect-url'?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponseString'];
+        };
+      };
+      /** @description 경로 변수 값이 누락되었습니다. */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      /** @description 유효하지 않은 JWT입니다. */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      /** @description 권한이 없습니다. */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      /** @description 지원하지 않는 URL입니다. */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      /** @description 유효하지 않은 Http 메서드입니다. */
+      405: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      /** @description 외부 서버 오류입니다. */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+    };
+  };
+  kakaoCallback_1: {
+    parameters: {
+      query: {
+        code: string;
+        'redirect-url'?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponseKaKaoLoginResponse'];
+        };
+      };
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      405: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+    };
+  };
+  kakaoCallback: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['OAuthLoginRequest'];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponseKaKaoLoginResponse'];
+        };
+      };
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      405: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+    };
+  };
   issueReport: {
     parameters: {
       query?: never;
@@ -1751,6 +2218,78 @@ export interface operations {
         };
         content: {
           '*/*': components['schemas']['BaseResponseIssueInsuranceReportResponse'];
+        };
+      };
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      405: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+    };
+  };
+  createdUrls: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['PresignedUrlRequest'];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponsePresignedUrlResponse'];
         };
       };
       400: {
@@ -2293,76 +2832,6 @@ export interface operations {
         };
       };
       /** @description 외부 서버 오류입니다. */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': unknown;
-        };
-      };
-    };
-  };
-  kakaoCallback: {
-    parameters: {
-      query: {
-        code: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['BaseResponseKaKaoLoginResponse'];
-        };
-      };
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': unknown;
-        };
-      };
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': unknown;
-        };
-      };
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': unknown;
-        };
-      };
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': unknown;
-        };
-      };
-      405: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': unknown;
-        };
-      };
       500: {
         headers: {
           [name: string]: unknown;

--- a/apps/client/src/widgets/login-fallback/hooks/use-social-login.ts
+++ b/apps/client/src/widgets/login-fallback/hooks/use-social-login.ts
@@ -2,24 +2,32 @@ import ky from '@toss/ky';
 import { useNavigate } from 'react-router';
 
 import { tokenService } from '@shared/auth/services/token-service';
+import { appConfig } from '@shared/configs/app-config';
 import { routePath } from '@shared/router/path';
 import { paths } from '@shared/types/schema';
 
 export const useSocialLogin = () => {
   const navigate = useNavigate();
   type KakaoResponse =
-    paths['/oauth/kakao/login']['get']['responses']['200']['content']['*/*']['data'];
+    paths['/oauth/kakao/login']['post']['responses']['200']['content']['*/*']['data'];
+
+  const getRedirectUrl = () =>
+    import.meta.env.MODE === 'development'
+      ? appConfig.auth.kakaoLocalRedirectUrl
+      : appConfig.auth.kakaoProdRedirectUrl;
 
   const kakaoLogin = async (code: string) => {
     if (!code) {
       throw new Error('코드가 존재하지 않습니다.');
     }
 
+    const redirectUrl = getRedirectUrl();
+
     try {
       const response = await ky
-        .get(
-          `${import.meta.env.VITE_API_BASE_URL}/oauth/kakao/login?code=${code}`,
-        )
+        .post(`${appConfig.api.baseUrl}/oauth/kakao/login`, {
+          json: { code, redirectUrl },
+        })
         .json<KakaoResponse>();
 
       const { accessToken, refreshToken } = response.data;


### PR DESCRIPTION
## 📌 Summary

- close #366

## 📚 Tasks

- get → post 변경
- generate:types 스크립트 실행
- 환경에 따라 redirectUrl 동적으로 변경


## 👀 To Reviewer
### 1. GET vs POST 사용 이유

기존 구조: GET 요청(code, redirect-url을 query param으로 전달)

문제점
- 인증/로그인 요청을 GET으로 처리하는 건 REST 관점에서 어색함
- query string에 민감한 값(code, redirect-url)이 그대로 노출 → 보안상 취약

선택: **POST** 방식
- JSON body로 안전하게 전달 가능
- Body 확장성 ↑ (provider, scope 등 추가 가능)
- 브라우저/프록시 캐싱 위험 없음

### 2. 분기 처리 위치 (use-social-login vs login-fallback)

LoginFallbackPage
- 역할: 카카오 인증 서버에서 redirect된 후 URL에서 code 추출
- (단순히 useSocialLogin 훅을 호출하는 역할만 수행)

useSocialLogin
- 역할: API 요청 + redirect-url 분기 + 토큰 저장 + 라우팅 처리
- provider 확장 시에도 이 훅만 수정하면 됨

🚀 환경 분기와 API 호출 로직은 useSocialLogin 안에 두고, LoginFallbackPage는 가볍게 유지


### 3. 환경 분기 (import.meta.env.MODE)

- Vite 제공 내장 변수인 env.MODE 사용
``` typescript
const redirectUrl =
  import.meta.env.MODE === 'development'
    ? appConfig.auth.kakaoLocalRedirectUrl
    : appConfig.auth.kakaoProdRedirectUrl;
```
- 실행 모드에 따라 자동으로 redirectUrl이 선택됨
- 로컬: development / 배포: production

### 4. 확장성 고려
- 현재는 Kakao만 지원하지만, 추후 Google/Naver 등 provider 추가 시에도 useSocialLogin 훅만 확장하면 됨!

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요시 .gif 형식으로 첨부해주세요.
-->
