### PR TITLE
Refactor(bds): 텍스트 버튼 수정 사항 반영 및 size 베리에이션 추가

### DIFF
--- a/apps/client/src/pages/community/community-edit/community-edit.tsx
+++ b/apps/client/src/pages/community/community-edit/community-edit.tsx
@@ -99,6 +99,7 @@ const CommunityEdit = () => {
         }
         rightIcon={
           <TextButton
+            size="sm"
             color="primary"
             disabled={isDisabled}
             onClick={() => {

--- a/apps/client/src/pages/community/community-write/community-write.tsx
+++ b/apps/client/src/pages/community/community-write/community-write.tsx
@@ -81,7 +81,7 @@ const CommunityWrite = () => {
         leftIcon={<Icon name="caret_left_lg" width="2.4rem" height="2.4rem" />}
         onClickLeft={handleGoBack}
         rightIcon={
-          <TextButton color="primary" disabled={isDisabled}>
+          <TextButton color="primary" disabled={isDisabled} size="sm">
             {COMMUNITY_CONTENT.BUTTON}
           </TextButton>
         }

--- a/apps/client/src/pages/onboarding/onboarding-page.tsx
+++ b/apps/client/src/pages/onboarding/onboarding-page.tsx
@@ -221,7 +221,7 @@ const OnboardingPage = () => {
               <Button variant="primary" size="lg" onClick={() => handleGo(1)}>
                 정보 입력 시작하기
               </Button>
-              <TextButton color="black" onClick={handleGoHome}>
+              <TextButton color="black" onClick={handleGoHome} size="sm">
                 나중에 추천받을래요
               </TextButton>
             </>

--- a/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
+++ b/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
@@ -33,7 +33,7 @@ const UserComment = ({
         </div>
         <div className={styles.button}>
           {isCommentOwner ? (
-            <TextButton color="black" onClick={onClickDelete}>
+            <TextButton color="black" onClick={onClickDelete} size="sm">
               {DELETE_CONTENT}
             </TextButton>
           ) : (

--- a/apps/client/src/widgets/community/components/user-detail-meta/user-detail-meta.tsx
+++ b/apps/client/src/widgets/community/components/user-detail-meta/user-detail-meta.tsx
@@ -36,6 +36,7 @@ const UserDetailMeta = ({
       {isOwner ? (
         <div className={styles.button}>
           <TextButton
+            size="sm"
             color="primary"
             style={{ padding: '0.6rem 0.8rem' }}
             onClick={onEditClick}
@@ -43,6 +44,7 @@ const UserDetailMeta = ({
             {BUTTON_TEXT.EDIT}
           </TextButton>
           <TextButton
+            size="sm"
             color="black"
             style={{ padding: '0.6rem 0.8rem' }}
             onClick={onDeleteClick}

--- a/apps/client/src/widgets/home/components/info-section/recommended-info-section.tsx
+++ b/apps/client/src/widgets/home/components/info-section/recommended-info-section.tsx
@@ -139,7 +139,7 @@ export const RecommendedInfoSection = ({
         })}
       </Swiper>
       <div className={styles.bottomButton}>
-        <TextButton color={'white'} onClick={handleNavigateReport}>
+        <TextButton color={'white'} size="sm" onClick={handleNavigateReport}>
           <p>구체적인 내용 확인하기</p>
           <Icon name={'caret_right_md'} color="white" />
         </TextButton>

--- a/packages/bds-ui/.storybook/preview.tsx
+++ b/packages/bds-ui/.storybook/preview.tsx
@@ -15,6 +15,19 @@ const preview: Preview = {
       element: '#root',
       manual: false,
     },
+    backgrounds: {
+      default: 'light',
+      values: [
+        {
+          name: 'light',
+          value: '#ffffff',
+        },
+        {
+          name: 'dark',
+          value: '#333333',
+        },
+      ],
+    },
   },
   decorators: [
     (Story) => (

--- a/packages/bds-ui/src/components/text-button/text-button.css.ts
+++ b/packages/bds-ui/src/components/text-button/text-button.css.ts
@@ -1,16 +1,15 @@
 import { style, styleVariants } from '@vanilla-extract/css';
 
 import { themeVars } from '../../styles';
+import { fontStyles } from '../../styles/tokens/font-style';
 
 export const base = style({
-  ...themeVars.fontStyles.title_sb_16,
-  padding: '0.6rem 1.6rem',
-  display: 'flex',
+  display: 'inline-flex',
   alignItems: 'center',
-  gap: '0.8rem',
+  justifyContent: 'center',
 });
 
-export const buttonColor = styleVariants({
+export const textButtonColor = styleVariants({
   black: [
     base,
     {
@@ -59,3 +58,21 @@ export const buttonColor = styleVariants({
     },
   ],
 });
+
+export const textButtonSizes = styleVariants({
+  xsm: {
+    ...fontStyles.body1_m_12,
+    height: '2.8rem',
+    padding: '0.4rem 0.6rem 0.4rem 1.2rem',
+    gap: '0.2rem',
+  },
+  sm: {
+    ...fontStyles.title_sb_16,
+    height: '3.6rem',
+    padding: '0.6rem 0.8rem 0.6rem 1.6rem',
+    gap: '0.4rem',
+  },
+});
+
+export type textButtonColor = keyof typeof textButtonColor;
+export type textButtonSizes = keyof typeof textButtonSizes;

--- a/packages/bds-ui/src/components/text-button/text-button.css.ts
+++ b/packages/bds-ui/src/components/text-button/text-button.css.ts
@@ -7,6 +7,7 @@ export const base = style({
   display: 'inline-flex',
   alignItems: 'center',
   justifyContent: 'center',
+  gap: '0.2rem',
 });
 
 export const textButtonColor = styleVariants({
@@ -60,17 +61,9 @@ export const textButtonColor = styleVariants({
 });
 
 export const textButtonSizes = styleVariants({
-  xsm: {
-    ...fontStyles.body1_m_12,
-    height: '2.8rem',
-    padding: '0.4rem 0.6rem 0.4rem 1.2rem',
-    gap: '0.2rem',
-  },
   sm: {
     ...fontStyles.title_sb_16,
-    height: '3.6rem',
-    padding: '0.6rem 0.8rem 0.6rem 1.6rem',
-    gap: '0.4rem',
+    height: '2.4rem',
   },
 });
 

--- a/packages/bds-ui/src/components/text-button/text-button.css.ts
+++ b/packages/bds-ui/src/components/text-button/text-button.css.ts
@@ -34,7 +34,7 @@ export const textButtonColor = styleVariants({
 
       selectors: {
         '&:not(:disabled):active': {
-          color: themeVars.color.gray100,
+          color: themeVars.color.primary100,
         },
         '&:disabled': {
           color: themeVars.color.gray400,

--- a/packages/bds-ui/src/components/text-button/text-button.css.ts
+++ b/packages/bds-ui/src/components/text-button/text-button.css.ts
@@ -11,6 +11,21 @@ export const base = style({
 });
 
 export const textButtonColor = styleVariants({
+  error: [
+    base,
+    {
+      color: themeVars.color.error,
+
+      selectors: {
+        '&:not(:disabled):active': {
+          color: themeVars.color.gray200,
+        },
+        '&:disabled': {
+          color: themeVars.color.errorSurface,
+        },
+      },
+    },
+  ],
   black: [
     base,
     {

--- a/packages/bds-ui/src/components/text-button/text-button.stories.tsx
+++ b/packages/bds-ui/src/components/text-button/text-button.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
+import { Icon } from '@bds/ui/icons';
+
 import TextButton from './text-button';
 
 const meta: Meta<typeof TextButton> = {
@@ -13,12 +15,13 @@ const meta: Meta<typeof TextButton> = {
         component: `
 TextButton 컴포넌트는 색상 스타일만 적용된 텍스트 형태의 버튼입니다.
 
-- \`color\`: 텍스트 색상 스타일 ('black' | 'primary')
+- \`color\`: 텍스트 색상 스타일 ('black' | 'primary' | 'white')
+- \`size\`: 버튼 크기 ('xsm' | 'sm')
 - \`disabled\`: 버튼 비활성화 여부
 - \`children\`: 버튼에 들어갈 콘텐츠
-- 기타 HTML 기본 \`button\` 속성 사용 가능
+- 아이콘 포함 사용 가능 (children 내부에 \`<Icon />\` 추가)
 
-활성/비활성 및 클릭 시 스타일이 바뀌며, 가벼운 액션 버튼에 적합합니다.
+가벼운 액션 버튼에 적합합니다.
         `,
       },
     },
@@ -44,7 +47,21 @@ TextButton 컴포넌트는 색상 스타일만 적용된 텍스트 형태의 버
   args: {
     children: '텍스트 버튼',
     color: 'black',
+    size: 'sm',
     disabled: false,
+  },
+  argTypes: {
+    color: {
+      control: { type: 'radio' },
+      options: ['black', 'primary', 'white'],
+    },
+    size: {
+      control: { type: 'radio' },
+      options: ['xsm', 'sm'],
+    },
+    disabled: {
+      control: 'boolean',
+    },
   },
 };
 
@@ -65,8 +82,20 @@ export const Primary: Story = {
   },
 };
 
+export const WithIcon: Story = {
+  args: {
+    color: 'white',
+    size: 'sm',
+    children: (
+      <>
+        <p>구체적인 내용 확인하기</p>
+        <Icon name="caret_right_md" color="white" />
+      </>
+    ),
+  },
+};
+
 export const DisabledBlack: Story = {
-  name: 'disabled black',
   args: {
     color: 'black',
     disabled: true,
@@ -75,18 +104,9 @@ export const DisabledBlack: Story = {
 };
 
 export const DisabledPrimary: Story = {
-  name: 'disabled primary',
   args: {
     color: 'primary',
     disabled: true,
     children: '비활성 프라이머리',
-  },
-};
-
-export const White: Story = {
-  name: 'white',
-  args: {
-    color: 'white',
-    children: '화이트 버튼',
   },
 };

--- a/packages/bds-ui/src/components/text-button/text-button.stories.tsx
+++ b/packages/bds-ui/src/components/text-button/text-button.stories.tsx
@@ -15,7 +15,7 @@ const meta: Meta<typeof TextButton> = {
         component: `
 TextButton 컴포넌트는 색상 스타일만 적용된 텍스트 형태의 버튼입니다.
 
-- \`color\`: 텍스트 색상 스타일 ('black' | 'primary' | 'white')
+- \`color\`: 텍스트 색상 스타일 ('black' | 'primary' | 'white' | 'error')
 - \`size\`: 버튼 크기 ('sm')
 - \`disabled\`: 버튼 비활성화 여부
 - \`children\`: 버튼에 들어갈 콘텐츠 (아이콘 조합 가능)
@@ -52,7 +52,7 @@ TextButton 컴포넌트는 색상 스타일만 적용된 텍스트 형태의 버
   argTypes: {
     color: {
       control: { type: 'radio' },
-      options: ['black', 'primary', 'white'],
+      options: ['black', 'primary', 'white', 'error'],
     },
     size: {
       control: { type: 'radio' },
@@ -120,5 +120,20 @@ export const DisabledPrimary: Story = {
     color: 'primary',
     disabled: true,
     children: '비활성 프라이머리',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    color: 'error',
+    children: '에러 버튼',
+  },
+};
+
+export const DisabledError: Story = {
+  args: {
+    color: 'error',
+    disabled: true,
+    children: '비활성 에러',
   },
 };

--- a/packages/bds-ui/src/components/text-button/text-button.stories.tsx
+++ b/packages/bds-ui/src/components/text-button/text-button.stories.tsx
@@ -16,10 +16,9 @@ const meta: Meta<typeof TextButton> = {
 TextButton 컴포넌트는 색상 스타일만 적용된 텍스트 형태의 버튼입니다.
 
 - \`color\`: 텍스트 색상 스타일 ('black' | 'primary' | 'white')
-- \`size\`: 버튼 크기 ('xsm' | 'sm')
+- \`size\`: 버튼 크기 ('sm')
 - \`disabled\`: 버튼 비활성화 여부
-- \`children\`: 버튼에 들어갈 콘텐츠
-- 아이콘 포함 사용 가능 (children 내부에 \`<Icon />\` 추가)
+- \`children\`: 버튼에 들어갈 콘텐츠 (아이콘 조합 가능)
 
 가벼운 액션 버튼에 적합합니다.
         `,
@@ -57,7 +56,7 @@ TextButton 컴포넌트는 색상 스타일만 적용된 텍스트 형태의 버
     },
     size: {
       control: { type: 'radio' },
-      options: ['xsm', 'sm'],
+      options: ['sm'],
     },
     disabled: {
       control: 'boolean',
@@ -82,13 +81,20 @@ export const Primary: Story = {
   },
 };
 
+export const White: Story = {
+  args: {
+    color: 'white',
+    children: '화이트 버튼',
+  },
+};
+
 export const WithIcon: Story = {
   args: {
     color: 'white',
     size: 'sm',
     children: (
       <>
-        <p>구체적인 내용 확인하기</p>
+        <span>구체적인 내용 확인하기</span>
         <Icon name="caret_right_md" color="white" />
       </>
     ),

--- a/packages/bds-ui/src/components/text-button/text-button.stories.tsx
+++ b/packages/bds-ui/src/components/text-button/text-button.stories.tsx
@@ -86,6 +86,9 @@ export const White: Story = {
     color: 'white',
     children: '화이트 버튼',
   },
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
 };
 
 export const WithIcon: Story = {
@@ -98,6 +101,9 @@ export const WithIcon: Story = {
         <Icon name="caret_right_md" color="white" />
       </>
     ),
+  },
+  parameters: {
+    backgrounds: { default: 'dark' },
   },
 };
 

--- a/packages/bds-ui/src/components/text-button/text-button.tsx
+++ b/packages/bds-ui/src/components/text-button/text-button.tsx
@@ -1,10 +1,11 @@
 import { ButtonHTMLAttributes, ReactNode } from 'react';
 
-import { buttonColor } from './text-button.css';
+import { textButtonColor, textButtonSizes } from './text-button.css';
 
 interface TextButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: ReactNode;
-  color: 'black' | 'primary' | 'white';
+  color: textButtonColor;
+  size: textButtonSizes;
   disabled?: boolean;
 }
 
@@ -12,10 +13,15 @@ const TextButton = ({
   children,
   color,
   disabled = false,
+  size,
   ...props
 }: TextButtonProps) => {
   return (
-    <button className={buttonColor[color]} disabled={disabled} {...props}>
+    <button
+      className={`${textButtonColor[color]} ${textButtonSizes[size]}`}
+      disabled={disabled}
+      {...props}
+    >
       {children}
     </button>
   );


### PR DESCRIPTION
## 📌 Summary

- #373 

## 📚 Tasks

- size 베리에이션을 추가했어요.
- 스토리북 파일도 수정했어요
- 사용처에서 size 를 명시하도록 했어요

## 👀 To Reviewer

바빠서 계속 작업을 못했는데, 실제로 코드를 작성해보니깐 문제점이 뭐인지 정확히 파악했어요. 애초에 텍스트 버튼과 그냥 버튼의 분리가 필요해요 같은 size 체계를 갖고있는데 실제로는 height 값이 다르고 요구 사항이 너무 달라서 디자이너에게 분리 요청해두었어요. 

꼭 아이콘에 종속되는게 아니라 어떤 칠드런이던 하나는 받을 수 있고 inline-flex 의 속성을 기본으로 갖고 있어서, 특정 리액트 엘리먼트가 들어오면 gap 이 사이즈에 따라서 달라지도록 설정했어요. 

피그마에 존재하는 UI 수정사항도 모두 반영했어요. 이제 정리됐네요 

정리하면 애초에 텍스트 버튼과 일반 버튼은 구분되어야하는게 맞아요. 불가능에 가까운 병합 작업이라 그냥 디자이너가 피그마 상에서 두개의 컴포넌트를 분리해주면 될 것 같아요.

<!--
## 🕶️ Requirements Checklist
- [ ]

(기능 명세서상 내용을 복사해서 테스트해주세요)
-->

## 📸 Screenshot

<img width="833" height="819" alt="image" src="https://github.com/user-attachments/assets/1371904a-1357-4d7f-848d-8a92e8b881e9" />

