### PR TITLE
HOTFIX(client): 온보딩 페이지 matching 단계 Navigation 나타남 해결

### DIFF
--- a/apps/client/src/pages/onboarding/onboarding-page.tsx
+++ b/apps/client/src/pages/onboarding/onboarding-page.tsx
@@ -147,6 +147,7 @@ const OnboardingPage = () => {
               title="정보입력"
             />
           ),
+          matching: () => null,
         }}
         defaultComponent={() => (
           <>


### PR DESCRIPTION
## 📌 Summary

- close #408 

온보딩 페이지 matching 단계에 Navigation을 삭제합니다. 

## 📚 Tasks

<img width="401" height="589" alt="image" src="https://github.com/user-attachments/assets/8c45fbe0-95de-4446-97fe-f2256264679c" />

matching 단계에는 navigation이 있으면 안되는데 온보딩 페이지 리팩토링을 하는 과정에서 이 부분을 놓쳤어요..
SwitchCase에 

```tsx
matching: () => null,
```

을 추가했습니다. 

<img width="326" height="477" alt="image" src="https://github.com/user-attachments/assets/b6bb2355-b708-4488-b38f-41576475c257" />


## 👀 To Reviewer

확인 안하고 머지 죄송합니다...고멘..
Ŏםŏ   ꌩ-ꌩ

<!--
## 🕶️ Requirements Checklist
- [ ]

(기능 명세서상 내용을 복사해서 테스트해주세요)
-->

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요시 .gif 형식으로 첨부해주세요.
-->
