### PR TITLE
Feat(client): 필터 드롭다운 컴포넌트 및 useToggle 훅 추가

### DIFF
--- a/apps/client/src/shared/hooks/use-toggle.ts
+++ b/apps/client/src/shared/hooks/use-toggle.ts
@@ -1,0 +1,32 @@
+import { useReducer } from 'react';
+
+/**
+ * @description
+ * `useToggle`은 boolean 상태를 간단하게 관리할 수 있도록 도와주는 React 훅입니다.
+ * 상태를 `true`와 `false` 사이에서 토글할 수 있는 함수를 제공합니다.
+ *
+ * @param {boolean} [initialValue=false] - 초기 상태 값. 기본값은 `false`입니다.
+ *
+ * @returns {[state: boolean, toggle: () => void]} 튜플을 반환합니다:
+ * - state `boolean` - 현재 상태 값
+ * - toggle `() => void` - 상태를 반전시키는 함수
+ *
+ * @example
+ * import { useToggle } from 'react-simplikit';
+ *
+ * function Component() {
+ *   const [open, toggle] = useToggle(false);
+ *
+ *   return (
+ *     <div>
+ *       <p>Bottom Sheet 상태: {open ? '열림' : '닫힘'}</p>
+ *       <button onClick={toggle}>토글</button>
+ *     </div>
+ *   );
+ * }
+ */
+export function useToggle(initialValue = false) {
+  return useReducer(toggle, initialValue);
+}
+
+const toggle = (state: boolean) => !state;

--- a/apps/client/src/shared/hooks/use-toggle.ts
+++ b/apps/client/src/shared/hooks/use-toggle.ts
@@ -12,7 +12,6 @@ import { useReducer } from 'react';
  * - toggle `() => void` - 상태를 반전시키는 함수
  *
  * @example
- * import { useToggle } from 'react-simplikit';
  *
  * function Component() {
  *   const [open, toggle] = useToggle(false);

--- a/apps/client/src/widgets/community/components/filter-dropdown/filter-dropdown.css.ts
+++ b/apps/client/src/widgets/community/components/filter-dropdown/filter-dropdown.css.ts
@@ -3,10 +3,10 @@ import { style } from '@vanilla-extract/css';
 import { themeVars } from '@bds/ui/styles';
 
 export const DropDownContainer = style({
+  position: 'relative',
   display: 'inline-flex',
   alignItems: 'flex-end',
   flexDirection: 'column',
-  gap: '0.8rem',
 });
 
 export const DropDownTitle = style({
@@ -23,6 +23,8 @@ export const DropDownIcon = style({
 });
 
 export const DropDownContent = style({
+  position: 'absolute',
+  top: '3.2rem',
   width: '9rem',
   display: 'flex',
   padding: '0.6rem 0',

--- a/apps/client/src/widgets/community/components/filter-dropdown/filter-dropdown.css.ts
+++ b/apps/client/src/widgets/community/components/filter-dropdown/filter-dropdown.css.ts
@@ -1,0 +1,35 @@
+import { style } from '@vanilla-extract/css';
+
+import { themeVars } from '@bds/ui/styles';
+
+export const DropDownContainer = style({
+  display: 'inline-flex',
+  alignItems: 'flex-end',
+  flexDirection: 'column',
+  gap: '0.8rem',
+});
+
+export const DropDownTitle = style({
+  ...themeVars.fontStyles.title_sb_16,
+  color: themeVars.color.gray800,
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.2rem',
+});
+
+export const DropDownIcon = style({
+  transition: 'transform 0.3s ease',
+  cursor: 'pointer',
+});
+
+export const DropDownContent = style({
+  width: '9rem',
+  display: 'flex',
+  padding: '0.6rem 0',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: '0.8rem',
+  borderRadius: '1.2rem',
+  border: `1px solid ${themeVars.color.gray200}`,
+  background: themeVars.color.white,
+});

--- a/apps/client/src/widgets/community/components/filter-dropdown/filter-dropdown.tsx
+++ b/apps/client/src/widgets/community/components/filter-dropdown/filter-dropdown.tsx
@@ -1,0 +1,39 @@
+import { Children, ReactNode } from 'react';
+
+import { Icon } from '@bds/ui/icons';
+
+import { useToggle } from '@shared/hooks/use-toggle';
+
+import * as styles from './filter-dropdown.css';
+
+interface FilterDropDownProps {
+  optionTitle: string;
+  children: ReactNode;
+}
+
+const FilterDropDown = ({ optionTitle, children }: FilterDropDownProps) => {
+  const [open, toggle] = useToggle(false);
+
+  return (
+    <div className={styles.DropDownContainer}>
+      <div className={styles.DropDownTitle}>
+        {optionTitle}
+        <Icon
+          name="caret_down_sm"
+          rotate={open ? undefined : 180}
+          className={styles.DropDownIcon}
+          onClick={toggle}
+        />
+      </div>
+      {open && (
+        <div className={styles.DropDownContent}>
+          {Children.map(children, (child, idx) => (
+            <div key={idx}>{child}</div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default FilterDropDown;


### PR DESCRIPTION
## 📌 Summary

- #411 

## 📚 Tasks

- 커뮤니티에서 사용되는 필터 드롭다운을 구현해두었어요.


## 👀 To Reviewer

```typescript
      <FilterDropDown optionTitle="최신순">
        <TextButton size="sm" color="black">
          최신순
        </TextButton>
        <TextButton size="sm" color="black">
          인기순
        </TextButton>
      </FilterDropDown>
```
사용처에서는 이런식으로 사용가능해요 컬러가 달라질 때의 코드는 사용처에서 명시해두어야 할 것 같아요. 

문제는 온보딩에도 dropdown 이라는 이름의 컴포넌트가 존재하는건데, 이 부분은 추후에 dropdown 을 공통 디자인 시스템으로 설계해달라고 디자인파트와의 조율이 필요한 부분인 것 같아요. 우선 지금은 따로 구현해두었어요

useToggle 커스텀훅 주석을 한번 읽어보시고 앞으로 개발할때 활용하면 편할 것 같아요

`Children` 은 리액트에서 칠드런을 안전하고 유연하게 다루기 위해 제공되는 유틸리티 객체이고, 단일/배열/undefined 일때 모두 안전하게 다룰 수 있어요. 

이 밖에도 map메서드를 순회하면서 key 가 없으면 자동으로 index 기반 key를 생성해줘요

<!--
## 🕶️ Requirements Checklist
- [ ]

(기능 명세서상 내용을 복사해서 테스트해주세요)
-->

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요시 .gif 형식으로 첨부해주세요.
-->
