### PR TITLE
Feat(client): 댓글 컴포넌트 사진 추가 및 대댓글 보기 구현

### DIFF
--- a/apps/client/src/shared/types/type.ts
+++ b/apps/client/src/shared/types/type.ts
@@ -1,1 +1,6 @@
 export type StatusType = '충분' | '부족' | '강력';
+
+export interface Image {
+  imageId?: number;
+  imageUrl?: string;
+}

--- a/apps/client/src/widgets/community/components/user-comment-info/user-comment-info.css.ts
+++ b/apps/client/src/widgets/community/components/user-comment-info/user-comment-info.css.ts
@@ -1,0 +1,60 @@
+import { style } from '@vanilla-extract/css';
+
+import { themeVars } from '@bds/ui/styles';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.4rem',
+});
+
+export const commentContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.2rem',
+});
+
+export const userInfoContainer = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  backgroundColor: 'transparent',
+});
+
+export const userInfo = style({
+  display: 'flex',
+  gap: '1.2rem',
+  alignItems: 'center',
+  backgroundColor: 'transparent',
+});
+
+export const nickName = style({
+  ...themeVars.fontStyles.title_sb_16,
+  color: themeVars.color.gray900,
+});
+
+export const timestamp = style({
+  ...themeVars.fontStyles.body1_m_12,
+  color: themeVars.color.gray600,
+});
+
+export const button = style({
+  display: 'flex',
+  alignItems: 'center',
+});
+
+export const comment = style({
+  ...themeVars.fontStyles.body1_m_16,
+  color: themeVars.color.gray900,
+  backgroundColor: 'transparent',
+});
+
+export const imageContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.2rem',
+});
+
+export const postImage = style({
+  width: '100%',
+  borderRadius: '1.2rem',
+});

--- a/apps/client/src/widgets/community/components/user-comment-info/user-comment-info.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-info/user-comment-info.tsx
@@ -35,12 +35,10 @@ const UserCommentInfo = ({ comment, imageUrl }: UserCommentInfoProps) => {
             </div>
           </div>
           <div className={styles.button}>
-            {isCommentOwner ? (
+            {isCommentOwner && (
               <TextButton color="black" onClick={onClickDelete} size="sm">
                 {DELETE_CONTENT}
               </TextButton>
-            ) : (
-              ''
             )}
           </div>
         </div>

--- a/apps/client/src/widgets/community/components/user-comment-info/user-comment-info.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-info/user-comment-info.tsx
@@ -48,20 +48,17 @@ const UserCommentInfo = ({
         </div>
         <p className={styles.comment}>{content}</p>
       </div>
-      {imageUrl.length > 0 && (
-        <div className={styles.imageContainer}>
-          {imageUrl.map((image) =>
-            image.imageUrl && image.imageUrl.trim() !== '' ? (
-              <img
-                key={image.imageId}
-                className={styles.postImage}
-                src={image.imageUrl}
-                alt="post image"
-              />
-            ) : null,
-          )}
-        </div>
-      )}
+      {imageUrl
+        .filter((image) => image.imageUrl?.trim())
+        .map((image) => (
+          <div key={image.imageId} className={styles.imageContainer}>
+            <img
+              className={styles.postImage}
+              src={image.imageUrl}
+              alt="post image"
+            />
+          </div>
+        ))}
     </div>
   );
 };

--- a/apps/client/src/widgets/community/components/user-comment-info/user-comment-info.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-info/user-comment-info.tsx
@@ -1,6 +1,6 @@
 import { Avatar, TextButton } from '@bds/ui';
 
-import { CommunityCommentType } from '@widgets/community/types/community-comment.type.ts';
+import { CommentType } from '@widgets/community/types/community-comment.type.ts';
 
 import { Image } from '@shared/types/type.ts';
 
@@ -9,7 +9,7 @@ import * as styles from './user-comment-info.css';
 const DELETE_CONTENT = '삭제';
 
 interface UserCommentInfoProps {
-  comment: CommunityCommentType;
+  comment: CommentType;
   imageUrl: Image[];
 }
 

--- a/apps/client/src/widgets/community/components/user-comment-info/user-comment-info.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-info/user-comment-info.tsx
@@ -1,5 +1,7 @@
 import { Avatar, TextButton } from '@bds/ui';
 
+import { CommunityCommentType } from '@widgets/community/types/community-comment.type.ts';
+
 import { Image } from '@shared/types/type.ts';
 
 import * as styles from './user-comment-info.css';
@@ -7,24 +9,20 @@ import * as styles from './user-comment-info.css';
 const DELETE_CONTENT = '삭제';
 
 interface UserCommentInfoProps {
-  content?: string;
-  writerNickName?: string;
-  createdAt?: string;
-  onClickDelete?: VoidFunction;
-  profileImage?: string;
-  isCommentOwner: boolean;
+  comment: CommunityCommentType;
   imageUrl: Image[];
 }
 
-const UserCommentInfo = ({
-  content,
-  writerNickName,
-  createdAt,
-  onClickDelete,
-  profileImage,
-  isCommentOwner,
-  imageUrl,
-}: UserCommentInfoProps) => {
+const UserCommentInfo = ({ comment, imageUrl }: UserCommentInfoProps) => {
+  const {
+    content,
+    writerNickName,
+    createdAt,
+    profileImage,
+    isCommentOwner,
+    onClickDelete,
+  } = comment;
+
   return (
     <div className={styles.container}>
       <div className={styles.commentContainer}>
@@ -49,14 +47,10 @@ const UserCommentInfo = ({
         <p className={styles.comment}>{content}</p>
       </div>
       {imageUrl
-        .filter((image) => image.imageUrl?.trim())
-        .map((image) => (
-          <div key={image.imageId} className={styles.imageContainer}>
-            <img
-              className={styles.postImage}
-              src={image.imageUrl}
-              alt="post image"
-            />
+        .filter(({ imageUrl }) => imageUrl?.trim())
+        .map(({ imageId, imageUrl }) => (
+          <div key={imageId} className={styles.imageContainer}>
+            <img className={styles.postImage} src={imageUrl} alt="post image" />
           </div>
         ))}
     </div>

--- a/apps/client/src/widgets/community/components/user-comment-info/user-comment-info.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-info/user-comment-info.tsx
@@ -10,10 +10,10 @@ const DELETE_CONTENT = '삭제';
 
 interface UserCommentInfoProps {
   comment: CommentType;
-  imageUrl?: Image[];
+  images?: Image[];
 }
 
-const UserCommentInfo = ({ comment, imageUrl }: UserCommentInfoProps) => {
+const UserCommentInfo = ({ comment, images }: UserCommentInfoProps) => {
   const {
     content,
     writerNickName,
@@ -22,6 +22,9 @@ const UserCommentInfo = ({ comment, imageUrl }: UserCommentInfoProps) => {
     isCommentOwner,
     onClickDelete,
   } = comment;
+
+  const commentImages =
+    images?.filter(({ imageUrl }) => imageUrl?.trim()) ?? [];
 
   return (
     <div className={styles.container}>
@@ -44,17 +47,15 @@ const UserCommentInfo = ({ comment, imageUrl }: UserCommentInfoProps) => {
         </div>
         <p className={styles.comment}>{content}</p>
       </div>
-      {imageUrl
-        ?.filter(({ imageUrl }) => imageUrl?.trim())
-        .map(({ imageId, imageUrl }) => (
-          <div key={imageId} className={styles.imageContainer}>
-            <img
-              className={styles.postImage}
-              src={imageUrl}
-              alt={`${writerNickName}님의 댓글 ${imageId}번째 이미지 `}
-            />
-          </div>
-        ))}
+      {commentImages.map(({ imageId, imageUrl }) => (
+        <div key={imageId} className={styles.imageContainer}>
+          <img
+            className={styles.postImage}
+            src={imageUrl}
+            alt={`${writerNickName}님의 댓글 ${imageId}번째 이미지 `}
+          />
+        </div>
+      ))}
     </div>
   );
 };

--- a/apps/client/src/widgets/community/components/user-comment-info/user-comment-info.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-info/user-comment-info.tsx
@@ -1,0 +1,69 @@
+import { Avatar, TextButton } from '@bds/ui';
+
+import { Image } from '@shared/types/type.ts';
+
+import * as styles from './user-comment-info.css';
+
+const DELETE_CONTENT = '삭제';
+
+interface UserCommentInfoProps {
+  content?: string;
+  writerNickName?: string;
+  createdAt?: string;
+  onClickDelete?: VoidFunction;
+  profileImage?: string;
+  isCommentOwner: boolean;
+  imageUrl: Image[];
+}
+
+const UserCommentInfo = ({
+  content,
+  writerNickName,
+  createdAt,
+  onClickDelete,
+  profileImage,
+  isCommentOwner,
+  imageUrl,
+}: UserCommentInfoProps) => {
+  return (
+    <div className={styles.container}>
+      <div className={styles.commentContainer}>
+        <div className={styles.userInfoContainer}>
+          <div className={styles.userInfo}>
+            <Avatar size="md" src={profileImage} />
+            <div>
+              <h2 className={styles.nickName}>{writerNickName}</h2>
+              <p className={styles.timestamp}>{createdAt}</p>
+            </div>
+          </div>
+          <div className={styles.button}>
+            {isCommentOwner ? (
+              <TextButton color="black" onClick={onClickDelete} size="sm">
+                {DELETE_CONTENT}
+              </TextButton>
+            ) : (
+              ''
+            )}
+          </div>
+        </div>
+        <p className={styles.comment}>{content}</p>
+      </div>
+      {imageUrl.length > 0 && (
+        <div className={styles.imageContainer}>
+          {imageUrl.map((image) =>
+            image.imageUrl && image.imageUrl.trim() !== '' ? (
+              <img
+                key={image.imageId}
+                className={styles.postImage}
+                src={image.imageUrl}
+                alt="post image"
+              />
+            ) : null,
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default UserCommentInfo;

--- a/apps/client/src/widgets/community/components/user-comment-info/user-comment-info.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-info/user-comment-info.tsx
@@ -10,7 +10,7 @@ const DELETE_CONTENT = '삭제';
 
 interface UserCommentInfoProps {
   comment: CommentType;
-  imageUrl: Image[];
+  imageUrl?: Image[];
 }
 
 const UserCommentInfo = ({ comment, imageUrl }: UserCommentInfoProps) => {
@@ -45,7 +45,7 @@ const UserCommentInfo = ({ comment, imageUrl }: UserCommentInfoProps) => {
         <p className={styles.comment}>{content}</p>
       </div>
       {imageUrl
-        .filter(({ imageUrl }) => imageUrl?.trim())
+        ?.filter(({ imageUrl }) => imageUrl?.trim())
         .map(({ imageId, imageUrl }) => (
           <div key={imageId} className={styles.imageContainer}>
             <img

--- a/apps/client/src/widgets/community/components/user-comment-info/user-comment-info.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-info/user-comment-info.tsx
@@ -48,7 +48,11 @@ const UserCommentInfo = ({ comment, imageUrl }: UserCommentInfoProps) => {
         .filter(({ imageUrl }) => imageUrl?.trim())
         .map(({ imageId, imageUrl }) => (
           <div key={imageId} className={styles.imageContainer}>
-            <img className={styles.postImage} src={imageUrl} alt="post image" />
+            <img
+              className={styles.postImage}
+              src={imageUrl}
+              alt={`${writerNickName}님의 댓글 ${imageId}번째 이미지 `}
+            />
           </div>
         ))}
     </div>

--- a/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
@@ -71,6 +71,8 @@ const UserCommentList = ({
                   profileImage={comment.profileImage}
                   isCommentOwner={isCommentOwner}
                   onClickDelete={() => onDeleteClick(String(comment.commentId))}
+                  replyCount={comment.replyCount ?? 0}
+                  imageUrl={comment.images ?? []}
                 />
               );
             })

--- a/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
@@ -66,21 +66,25 @@ const UserCommentList = ({
                 profileImage,
                 replyCount,
                 images,
-              }) => (
-                <UserComment
-                  key={commentId}
-                  comment={{
-                    content: content,
-                    writerNickName: writerNickname,
-                    createdAt: getTimeAgo(createdAt),
-                    profileImage: profileImage,
-                    isCommentOwner: writerId === commentOwnerId,
-                    onClickDelete: () => onDeleteClick(String(commentId)),
-                  }}
-                  replyCount={replyCount ?? 0}
-                  imageUrl={images ?? []}
-                />
-              ),
+              }) => {
+                const commentImages = images?.length ? images : undefined;
+
+                return (
+                  <UserComment
+                    key={commentId}
+                    comment={{
+                      content: content,
+                      writerNickName: writerNickname,
+                      createdAt: getTimeAgo(createdAt),
+                      profileImage: profileImage,
+                      isCommentOwner: writerId === commentOwnerId,
+                      onClickDelete: () => onDeleteClick(String(commentId)),
+                    }}
+                    replyCount={replyCount ?? 0}
+                    images={commentImages}
+                  />
+                );
+              },
             )
           ) : (
             <div className={styles.placeholder}>

--- a/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
@@ -35,8 +35,12 @@ const UserCommentList = ({
     ...COMMUNITY_QUERY_OPTIONS.COMMENTS(postId),
   });
 
+  if (!comments) {
+    return null;
+  }
+
   const allComments =
-    comments?.pages.flatMap((page) => page?.data?.content ?? []) ?? [];
+    comments.pages.flatMap((page) => page?.data?.content ?? []) ?? [];
 
   const commentsObserverRef = useIntersectionObserver(() => {
     if (hasNextPage && !isFetchingNextPage) {

--- a/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
@@ -66,25 +66,21 @@ const UserCommentList = ({
                 profileImage,
                 replyCount,
                 images,
-              }) => {
-                const isCommentOwner = writerId === commentOwnerId;
-
-                return (
-                  <UserComment
-                    key={`${commentId}`}
-                    comment={{
-                      content: content,
-                      writerNickName: writerNickname,
-                      createdAt: getTimeAgo(createdAt),
-                      profileImage: profileImage,
-                      isCommentOwner: isCommentOwner,
-                      onClickDelete: () => onDeleteClick(String(commentId)),
-                    }}
-                    replyCount={replyCount ?? 0}
-                    imageUrl={images ?? []}
-                  />
-                );
-              },
+              }) => (
+                <UserComment
+                  key={commentId}
+                  comment={{
+                    content: content,
+                    writerNickName: writerNickname,
+                    createdAt: getTimeAgo(createdAt),
+                    profileImage: profileImage,
+                    isCommentOwner: writerId === commentOwnerId,
+                    onClickDelete: () => onDeleteClick(String(commentId)),
+                  }}
+                  replyCount={replyCount ?? 0}
+                  imageUrl={images ?? []}
+                />
+              ),
             )
           ) : (
             <div className={styles.placeholder}>

--- a/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
@@ -44,9 +44,6 @@ const UserCommentList = ({
     }
   }, true);
 
-  if (!comments) {
-    return null;
-  }
   return (
     <div>
       <article className={styles.commentMapContainer}>
@@ -59,23 +56,36 @@ const UserCommentList = ({
 
         <div className={styles.commentContainer}>
           {allComments.length > 0 ? (
-            allComments.map((comment) => {
-              const isCommentOwner = comment.writerId === commentOwnerId;
+            allComments.map(
+              ({
+                writerId,
+                commentId,
+                content,
+                writerNickname,
+                createdAt,
+                profileImage,
+                replyCount,
+                images,
+              }) => {
+                const isCommentOwner = writerId === commentOwnerId;
 
-              return (
-                <UserComment
-                  key={`${comment.commentId}`}
-                  content={comment.content}
-                  writerNickName={comment.writerNickname}
-                  createdAt={getTimeAgo(comment.createdAt)}
-                  profileImage={comment.profileImage}
-                  isCommentOwner={isCommentOwner}
-                  onClickDelete={() => onDeleteClick(String(comment.commentId))}
-                  replyCount={comment.replyCount ?? 0}
-                  imageUrl={comment.images ?? []}
-                />
-              );
-            })
+                return (
+                  <UserComment
+                    key={`${commentId}`}
+                    comment={{
+                      content: content,
+                      writerNickName: writerNickname,
+                      createdAt: getTimeAgo(createdAt),
+                      profileImage: profileImage,
+                      isCommentOwner: isCommentOwner,
+                      onClickDelete: () => onDeleteClick(String(commentId)),
+                    }}
+                    replyCount={replyCount ?? 0}
+                    imageUrl={images ?? []}
+                  />
+                );
+              },
+            )
           ) : (
             <div className={styles.placeholder}>
               <div className={styles.emptyPlaceholder}>

--- a/apps/client/src/widgets/community/components/user-comment/user-comment.css.ts
+++ b/apps/client/src/widgets/community/components/user-comment/user-comment.css.ts
@@ -1,47 +1,60 @@
 import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
 
 import { themeVars } from '@bds/ui/styles';
 
 export const container = style({
   display: 'flex',
   flexDirection: 'column',
-  padding: '1.2rem 1.6rem',
-  borderRadius: '12px',
-  width: '100%',
-  gap: '1.2rem',
-  backgroundColor: themeVars.color.whiteBackground,
+  gap: '0.8rem',
 });
 
 export const userInfoContainer = style({
   display: 'flex',
-  justifyContent: 'space-between',
-  backgroundColor: 'transparent',
+  flexDirection: 'column',
+  padding: '1.2rem 1.6rem',
+  borderRadius: '12px',
+  width: '100%',
+  gap: '0.4rem',
+  backgroundColor: themeVars.color.whiteBackground,
 });
 
-export const userInfo = style({
+export const replyContainer = style({
   display: 'flex',
-  gap: '1.2rem',
+  paddingLeft: '1.6rem',
   alignItems: 'center',
-  backgroundColor: 'transparent',
 });
 
-export const nickName = style({
-  ...themeVars.fontStyles.title_sb_16,
-  color: themeVars.color.gray900,
-});
-
-export const timestamp = style({
+export const reply = style({
   ...themeVars.fontStyles.body1_m_12,
-  color: themeVars.color.gray600,
+  color: themeVars.color.gray800,
 });
 
-export const button = style({
-  display: 'flex',
-  alignItems: 'center',
+export const iconRotate = recipe({
+  base: {
+    transition: 'transform 0.1s ease-in-out',
+  },
+  variants: {
+    rotated: {
+      true: {
+        transform: 'rotate(-180deg)',
+      },
+      false: {
+        transform: 'rotate(0deg)',
+      },
+    },
+  },
+  defaultVariants: {
+    rotated: false,
+  },
 });
 
-export const comment = style({
-  ...themeVars.fontStyles.body1_m_16,
-  color: themeVars.color.gray900,
-  backgroundColor: 'transparent',
+export const rotated = style({
+  transform: 'rotate(-180deg)',
+  transition: 'transform 0.1s ease-in-out',
+});
+
+export const reRotated = style({
+  transform: 'rotate(0deg)',
+  transition: 'transform 0.1s ease-in-out',
 });

--- a/apps/client/src/widgets/community/components/user-comment/user-comment.css.ts
+++ b/apps/client/src/widgets/community/components/user-comment/user-comment.css.ts
@@ -19,10 +19,14 @@ export const userInfoContainer = style({
   backgroundColor: themeVars.color.whiteBackground,
 });
 
+export const replyButtonContainer = style({
+  paddingLeft: '1.6rem',
+});
+
 export const replyContainer = style({
   display: 'flex',
-  paddingLeft: '1.6rem',
   alignItems: 'center',
+  width: 'fit-content',
 });
 
 export const reply = style({

--- a/apps/client/src/widgets/community/components/user-comment/user-comment.css.ts
+++ b/apps/client/src/widgets/community/components/user-comment/user-comment.css.ts
@@ -48,13 +48,3 @@ export const iconRotate = recipe({
     rotated: false,
   },
 });
-
-export const rotated = style({
-  transform: 'rotate(-180deg)',
-  transition: 'transform 0.1s ease-in-out',
-});
-
-export const reRotated = style({
-  transform: 'rotate(0deg)',
-  transition: 'transform 0.1s ease-in-out',
-});

--- a/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
+++ b/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
@@ -28,7 +28,7 @@ const UserComment = ({ comment, replyCount, imageUrl }: UserCommentProps) => {
       <div className={styles.userInfoContainer}>
         <UserCommentInfo comment={comment} imageUrl={imageUrl} />
         <p>
-          <TextButton size="sm" color="black">
+          <TextButton size="xs" color="black">
             답글 달기
           </TextButton>
         </p>

--- a/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
+++ b/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
@@ -26,7 +26,7 @@ const UserComment = ({ comment, replyCount, images }: UserCommentProps) => {
   return (
     <div className={styles.container}>
       <div className={styles.userInfoContainer}>
-        <UserCommentInfo comment={comment} imageUrl={images} />
+        <UserCommentInfo comment={comment} images={images} />
         <p>
           <TextButton size="xs" color="black">
             답글 달기

--- a/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
+++ b/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
@@ -4,14 +4,14 @@ import { TextButton } from '@bds/ui';
 import { Icon } from '@bds/ui/icons';
 
 import UserCommentInfo from '@widgets/community/components/user-comment-info/user-comment-info';
-import { CommunityCommentType } from '@widgets/community/types/community-comment.type.ts';
+import { CommentType } from '@widgets/community/types/community-comment.type.ts';
 
 import { Image } from '@shared/types/type.ts';
 
 import * as styles from './user-comment.css';
 
 interface UserCommentProps {
-  comment: CommunityCommentType;
+  comment: CommentType;
   replyCount: number;
   imageUrl: Image[];
 }

--- a/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
+++ b/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
@@ -1,4 +1,11 @@
-import { Avatar, TextButton } from '@bds/ui';
+import { useState } from 'react';
+
+import { TextButton } from '@bds/ui';
+import { Icon } from '@bds/ui/icons';
+
+import UserCommentInfo from '@widgets/community/components/user-comment-info/user-comment-info';
+
+import { Image } from '@shared/types/type.ts';
 
 import * as styles from './user-comment.css';
 
@@ -9,9 +16,9 @@ interface UserCommentProps {
   onClickDelete?: VoidFunction;
   profileImage?: string;
   isCommentOwner: boolean;
+  replyCount: number;
+  imageUrl: Image[];
 }
-
-const DELETE_CONTENT = '삭제';
 
 const UserComment = ({
   content,
@@ -20,29 +27,47 @@ const UserComment = ({
   onClickDelete,
   profileImage,
   isCommentOwner,
+  replyCount,
+  imageUrl,
 }: UserCommentProps) => {
+  const [isRotated, setIsRotated] = useState(false);
+
+  const handleIconClick = () => {
+    setIsRotated(!isRotated);
+  };
   return (
-    <article className={styles.container}>
-      <article className={styles.userInfoContainer}>
-        <div className={styles.userInfo}>
-          <Avatar size="md" src={profileImage} />
-          <div>
-            <h2 className={styles.nickName}>{writerNickName}</h2>
-            <p className={styles.timestamp}>{createdAt}</p>
-          </div>
-        </div>
-        <div className={styles.button}>
-          {isCommentOwner ? (
-            <TextButton color="black" onClick={onClickDelete} size="sm">
-              {DELETE_CONTENT}
-            </TextButton>
-          ) : (
-            ''
-          )}
-        </div>
-      </article>
-      <p className={styles.comment}>{content}</p>
-    </article>
+    <div className={styles.container}>
+      <div className={styles.userInfoContainer}>
+        <UserCommentInfo
+          content={content}
+          writerNickName={writerNickName}
+          createdAt={createdAt}
+          onClickDelete={onClickDelete}
+          profileImage={profileImage}
+          isCommentOwner={isCommentOwner}
+          imageUrl={imageUrl}
+        />
+        <p>
+          <TextButton size="sm" color="black">
+            답글 달기
+          </TextButton>
+        </p>
+      </div>
+      {replyCount > 0 && (
+        <button className={styles.replyContainer} onClick={handleIconClick}>
+          <Icon
+            name="caret_down_sm"
+            width="2.4rem"
+            height="2.4rem"
+            color="gray800"
+            className={styles.iconRotate({ rotated: isRotated })}
+          />
+          <p className={styles.reply}>
+            답글 {replyCount}개 {isRotated ? '접기' : '보기'}
+          </p>
+        </button>
+      )}
+    </div>
   );
 };
 

--- a/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
+++ b/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
@@ -4,49 +4,29 @@ import { TextButton } from '@bds/ui';
 import { Icon } from '@bds/ui/icons';
 
 import UserCommentInfo from '@widgets/community/components/user-comment-info/user-comment-info';
+import { CommunityCommentType } from '@widgets/community/types/community-comment.type.ts';
 
 import { Image } from '@shared/types/type.ts';
 
 import * as styles from './user-comment.css';
 
 interface UserCommentProps {
-  content?: string;
-  writerNickName?: string;
-  createdAt?: string;
-  onClickDelete?: VoidFunction;
-  profileImage?: string;
-  isCommentOwner: boolean;
+  comment: CommunityCommentType;
   replyCount: number;
   imageUrl: Image[];
 }
 
-const UserComment = ({
-  content,
-  writerNickName,
-  createdAt,
-  onClickDelete,
-  profileImage,
-  isCommentOwner,
-  replyCount,
-  imageUrl,
-}: UserCommentProps) => {
+const UserComment = ({ comment, replyCount, imageUrl }: UserCommentProps) => {
   const [isRotated, setIsRotated] = useState(false);
 
   const handleIconClick = () => {
     setIsRotated(!isRotated);
   };
+
   return (
     <div className={styles.container}>
       <div className={styles.userInfoContainer}>
-        <UserCommentInfo
-          content={content}
-          writerNickName={writerNickName}
-          createdAt={createdAt}
-          onClickDelete={onClickDelete}
-          profileImage={profileImage}
-          isCommentOwner={isCommentOwner}
-          imageUrl={imageUrl}
-        />
+        <UserCommentInfo comment={comment} imageUrl={imageUrl} />
         <p>
           <TextButton size="sm" color="black">
             답글 달기

--- a/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
+++ b/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
@@ -13,10 +13,10 @@ import * as styles from './user-comment.css';
 interface UserCommentProps {
   comment: CommentType;
   replyCount: number;
-  imageUrl: Image[];
+  images?: Image[];
 }
 
-const UserComment = ({ comment, replyCount, imageUrl }: UserCommentProps) => {
+const UserComment = ({ comment, replyCount, images }: UserCommentProps) => {
   const [isRotated, setIsRotated] = useState(false);
 
   const handleIconClick = () => {
@@ -26,7 +26,7 @@ const UserComment = ({ comment, replyCount, imageUrl }: UserCommentProps) => {
   return (
     <div className={styles.container}>
       <div className={styles.userInfoContainer}>
-        <UserCommentInfo comment={comment} imageUrl={imageUrl} />
+        <UserCommentInfo comment={comment} imageUrl={images} />
         <p>
           <TextButton size="xs" color="black">
             답글 달기

--- a/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
+++ b/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
@@ -34,18 +34,20 @@ const UserComment = ({ comment, replyCount, imageUrl }: UserCommentProps) => {
         </p>
       </div>
       {replyCount > 0 && (
-        <button className={styles.replyContainer} onClick={handleIconClick}>
-          <Icon
-            name="caret_down_sm"
-            width="2.4rem"
-            height="2.4rem"
-            color="gray800"
-            className={styles.iconRotate({ rotated: isRotated })}
-          />
-          <p className={styles.reply}>
-            답글 {replyCount}개 {isRotated ? '접기' : '보기'}
-          </p>
-        </button>
+        <div className={styles.replyButtonContainer}>
+          <button className={styles.replyContainer} onClick={handleIconClick}>
+            <Icon
+              name="caret_down_sm"
+              width="2.4rem"
+              height="2.4rem"
+              color="gray800"
+              className={styles.iconRotate({ rotated: isRotated })}
+            />
+            <p className={styles.reply}>
+              답글 {replyCount}개 {isRotated ? '접기' : '보기'}
+            </p>
+          </button>
+        </div>
       )}
     </div>
   );

--- a/apps/client/src/widgets/community/types/community-comment.type.ts
+++ b/apps/client/src/widgets/community/types/community-comment.type.ts
@@ -1,4 +1,4 @@
-export interface CommunityCommentType {
+export interface CommentType {
   content?: string;
   writerNickName?: string;
   createdAt?: string;

--- a/apps/client/src/widgets/community/types/community-comment.type.ts
+++ b/apps/client/src/widgets/community/types/community-comment.type.ts
@@ -1,0 +1,8 @@
+export interface CommunityCommentType {
+  content?: string;
+  writerNickName?: string;
+  createdAt?: string;
+  onClickDelete?: VoidFunction;
+  profileImage?: string;
+  isCommentOwner: boolean;
+}

--- a/packages/bds-ui/src/components/text-button/text-button.css.ts
+++ b/packages/bds-ui/src/components/text-button/text-button.css.ts
@@ -76,6 +76,10 @@ export const textButtonColor = styleVariants({
 });
 
 export const textButtonSizes = styleVariants({
+  xs: {
+    ...fontStyles.body1_m_12,
+    height: '1.7rem',
+  },
   sm: {
     ...fontStyles.title_sb_16,
     height: '2.4rem',

--- a/packages/bds-ui/src/components/text-button/text-button.stories.tsx
+++ b/packages/bds-ui/src/components/text-button/text-button.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof TextButton> = {
 TextButton 컴포넌트는 색상 스타일만 적용된 텍스트 형태의 버튼입니다.
 
 - \`color\`: 텍스트 색상 스타일 ('black' | 'primary' | 'white' | 'error')
-- \`size\`: 버튼 크기 ('sm')
+- \`size\`: 버튼 크기 ('xs' | 'sm')
 - \`disabled\`: 버튼 비활성화 여부
 - \`children\`: 버튼에 들어갈 콘텐츠 (아이콘 조합 가능)
 
@@ -56,7 +56,7 @@ TextButton 컴포넌트는 색상 스타일만 적용된 텍스트 형태의 버
     },
     size: {
       control: { type: 'radio' },
-      options: ['sm'],
+      options: ['xs', 'sm'],
     },
     disabled: {
       control: 'boolean',


### PR DESCRIPTION
## 📌 Summary

> - #415 

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._
- 댓글 컴포넌트 이미지 추가
- 댓글 `user-comment-info` 컴포넌트 분리
- 답글 보기 구현
- text-button variation 추가 ('xs')

## 📚 Tasks
기존 user-comment 컴포넌트에서 user-comment-info 컴포넌트를 새로 만들고 분리 시켰어요.
<img width="457" height="429" alt="image" src="https://github.com/user-attachments/assets/374cda2f-680b-4766-865d-aed4d46b4edf" />
user-comment-info 부분은 답글 달기 위쪽 영역, 그리고 사진까지 포함된 영역이에요. (햄버거 버튼은 이 PR에서 작업하지 않았어요.)  컴포넌트를 분리시킨 이유는 분리 하지 않으면 user-comment 컴포넌트가 담당하는 코드가 많아지고 div가 5~6 depth 까지 늘어나서 가독성이 떨어진다 판단되어 분리하였습니다. 그리고 퍼블리싱 할때도 편해지기도 했구용..
따라서 `user-comment-info`의 css파일은 기존 `user-comment` css를 그대로 옮겼다고 생각하시면 돼요.

imageUrl을 받아올 때 타입은 기존 `민정`의 PR 타입과 일치시켰어요. - #402

답글 보기 부분은 서버에서 오는 `replyCount(대댓글 수)`가 0 이상일때만 렌더링되도록 설정하였어요.

## 타입선언
```tsx
export interface CommentType {
  content?: string;
  writerNickName?: string;
  createdAt?: string;
  onClickDelete?: VoidFunction;
  profileImage?: string;
  isCommentOwner: boolean;
}
```
`user-comment-info` 컴포넌트를 분리하다 보니 위의 타입이 중복되어 하나의 타입으로 묶었어서 `user-comment` 컴포넌트와 `user-comment-info`컴포넌트에서 사용하였어요. 
하나의 타입으로 묶으니 `<UserCommentInfo comment={comment} imageUrl={imageUrl} />` 이처럼 props도 줄게 되어 코드도 깔끔해졌어요.  해당 컴포넌트 내에서는 `comment.content`, `comment.writerNickName`와 같이 사용할까 하다가 구조분해할당을 이용해서 사용하는게 더 코드도 깔끔해지고 직관적일것 같다고 생각하여
```tsx
const {
    content,
    writerNickName,
    createdAt,
    profileImage,
    isCommentOwner,
    onClickDelete,
  } = comment;
```
이처럼 코드를 구현하였습니다.

### TextButton 컴포넌트
디자인과 얘기한 결과 `text-button`의 size variation을 추가했어요.
```tsx
xs: {
    ...fontStyles.body1_m_12,
    height: '1.7rem',
},
```
처음에는 기존 `sm` 변수 명을 `md`로 변경하고 새로 추가된 사이즈를 `sm`로 변경할 생각이었어요. 하지만 현재 작업중인 분들도 많고 변경점이 많을것 같다고 생각하여 `sm`을 놔두고 `xs`로 추가했어요.

## 👀 To Reviewer
~피그마에 text-button 컴포넌트 variation 추가 요청 드린 상태여서 아직 `답글 달기` 부분 폰트가 안 맞아요! 이후 수정되면 Draft 풀도록 하겠습니다.~
- 머지되면 대댓글 컴포넌트 퍼블리싱과 api연동 작업 시작할게요!

<!--
## 🕶️ Requirements Checklist
- [ ]

(기능 명세서상 내용을 복사해서 테스트해주세요)
-->

## 📸 Screenshot

https://github.com/user-attachments/assets/ff5b5f32-d274-46d6-9304-535db3b23c8c

