### PR TITLE
Feat(client) : 글 작성 시 카테고리 기능 추가

### DIFF
--- a/apps/client/src/pages/community/community-write/community-write.css.ts
+++ b/apps/client/src/pages/community/community-write/community-write.css.ts
@@ -1,7 +1,5 @@
 import { style } from '@vanilla-extract/css';
 
-import { themeVars } from '@bds/ui/styles';
-
 export const container = style({
   display: 'flex',
   flexDirection: 'column',
@@ -33,12 +31,4 @@ export const postTitle = style({
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'space-between',
-});
-
-export const postCategory = style({
-  ...themeVars.fontStyles.title_sb_16,
-  color: themeVars.color.gray800,
-  display: 'flex',
-  alignItems: 'center',
-  gap: '0.2rem',
 });

--- a/apps/client/src/pages/community/community-write/community-write.css.ts
+++ b/apps/client/src/pages/community/community-write/community-write.css.ts
@@ -1,5 +1,7 @@
 import { style } from '@vanilla-extract/css';
 
+import { themeVars } from '@bds/ui/styles';
+
 export const container = style({
   display: 'flex',
   flexDirection: 'column',
@@ -25,4 +27,18 @@ export const postContent = style({
   display: 'flex',
   flexDirection: 'column',
   gap: '1.2rem',
+});
+
+export const postTitle = style({
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+});
+
+export const postCategory = style({
+  ...themeVars.fontStyles.title_sb_16,
+  color: themeVars.color.gray800,
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.2rem',
 });

--- a/apps/client/src/pages/community/community-write/community-write.tsx
+++ b/apps/client/src/pages/community/community-write/community-write.tsx
@@ -32,6 +32,7 @@ const CommunityWrite = () => {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [isDisabled, setIsDisabled] = useState(true);
+  const [category, setCategory] = useState('');
   const queryClient = useQueryClient();
   const { isErrorState } = useLimitedInput(LIMIT_SHORT_TEXT, title.length);
   const { mutate } = useMutation({
@@ -93,7 +94,13 @@ const CommunityWrite = () => {
       />
       <div className={styles.postContainer}>
         <div className={styles.postHeader}>
-          <Title fontStyle="eb_md">{COMMUNITY_CONTENT.TITLE.HEADER}</Title>
+          <div className={styles.postTitle}>
+            <Title fontStyle="eb_md">{COMMUNITY_CONTENT.TITLE.HEADER}</Title>
+            <div className={styles.postCategory}>
+              <p>{category || '카테고리 선택'}</p>
+              <Icon name={'caret_down_sm'} />
+            </div>
+          </div>
           <Input
             value={title}
             onChange={handleTitleChange}

--- a/apps/client/src/pages/community/community-write/community-write.tsx
+++ b/apps/client/src/pages/community/community-write/community-write.tsx
@@ -6,6 +6,7 @@ import { Input, Navigation, TextButton, Title } from '@bds/ui';
 import { Icon } from '@bds/ui/icons';
 
 import CommunityLine from '@widgets/community/components/community-line/community-line';
+import FilterDropDown from '@widgets/community/components/filter-dropdown/filter-dropdown';
 import { PLACEHOLDER } from '@widgets/community/constant/input-placeholder';
 
 import { COMMUNITY_MUTATION_OPTIONS } from '@shared/api/domain/community/queries';
@@ -15,6 +16,7 @@ import {
   LIMIT_SHORT_TEXT,
 } from '@shared/constants/text-limits';
 import { useLimitedInput } from '@shared/hooks/use-limited-input';
+import { useToggle } from '@shared/hooks/use-toggle.ts';
 import { routePath } from '@shared/router/path';
 
 import * as styles from './community-write.css';
@@ -33,6 +35,8 @@ const CommunityWrite = () => {
   const [content, setContent] = useState('');
   const [isDisabled, setIsDisabled] = useState(true);
   const [category, setCategory] = useState('');
+  const [open, toggle] = useToggle(false);
+
   const queryClient = useQueryClient();
   const { isErrorState } = useLimitedInput(LIMIT_SHORT_TEXT, title.length);
   const { mutate } = useMutation({
@@ -78,6 +82,11 @@ const CommunityWrite = () => {
     }
   };
 
+  const handleCategory = () => {
+    // 카테고리 선택 기능 추후 구현
+    alert('카테고리 선택 기능은 추후 구현 예정입니다.');
+  };
+
   return (
     <div className={styles.container}>
       <Navigation
@@ -96,10 +105,17 @@ const CommunityWrite = () => {
         <div className={styles.postHeader}>
           <div className={styles.postTitle}>
             <Title fontStyle="eb_md">{COMMUNITY_CONTENT.TITLE.HEADER}</Title>
-            <div className={styles.postCategory}>
-              <p>{category || '카테고리 선택'}</p>
-              <Icon name={'caret_down_sm'} />
-            </div>
+            <FilterDropDown optionTitle="보험 QnA">
+              <TextButton size="sm" color="black">
+                보험 QnA
+              </TextButton>
+              <TextButton size="sm" color="black">
+                정보공유
+              </TextButton>
+              <TextButton size="sm" color="black">
+                사담
+              </TextButton>
+            </FilterDropDown>
           </div>
           <Input
             value={title}

--- a/apps/client/src/pages/community/community-write/community-write.tsx
+++ b/apps/client/src/pages/community/community-write/community-write.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { ChangeEvent, useCallback, useMemo, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
@@ -7,7 +7,9 @@ import { Icon } from '@bds/ui/icons';
 
 import CommunityLine from '@widgets/community/components/community-line/community-line';
 import FilterDropDown from '@widgets/community/components/filter-dropdown/filter-dropdown';
+import { categoryOptions } from '@widgets/community/configs/category-config';
 import { PLACEHOLDER } from '@widgets/community/constant/input-placeholder';
+import { CategoryType } from '@widgets/community/types/category-type';
 
 import { COMMUNITY_MUTATION_OPTIONS } from '@shared/api/domain/community/queries';
 import { COMMUNITY_QUERY_KEY } from '@shared/api/keys/query-key';
@@ -16,7 +18,6 @@ import {
   LIMIT_SHORT_TEXT,
 } from '@shared/constants/text-limits';
 import { useLimitedInput } from '@shared/hooks/use-limited-input';
-import { useToggle } from '@shared/hooks/use-toggle.ts';
 import { routePath } from '@shared/router/path';
 
 import * as styles from './community-write.css';
@@ -33,13 +34,11 @@ const CommunityWrite = () => {
   const navigate = useNavigate();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
-  const [isDisabled, setIsDisabled] = useState(true);
-  const [category, setCategory] = useState('');
-  const [open, toggle] = useToggle(false);
+  const [category, setCategory] = useState<CategoryType | null>(null);
 
   const queryClient = useQueryClient();
   const { isErrorState } = useLimitedInput(LIMIT_SHORT_TEXT, title.length);
-  const { mutate } = useMutation({
+  const { mutate, isPending } = useMutation({
     ...COMMUNITY_MUTATION_OPTIONS.POST_FEED(),
     onSuccess: () => {
       queryClient.invalidateQueries({
@@ -50,42 +49,47 @@ const CommunityWrite = () => {
   });
 
   const handlePostFeed = () => {
-    // @TODO category, imageUrls 는 타입 에러로 작성해둠. 추후 구현 시 수정 필요
+    if (isDisabled || !category) {
+      return;
+    }
+
+    // @TODO  imageUrls 는 타입 에러로 작성해둠. 추후 구현 시 수정 필요
     mutate({
-      title: title,
-      content: content,
-      category: '',
+      title,
+      content,
+      category: category.value,
       imageUrls: [],
     });
   };
 
-  useEffect(() => {
-    const isTitleValid = title.trim().length > 0;
-    const isContentValid = content.trim().length > 0;
+  const isTitleValid = useMemo(() => title.trim().length > 0, [title]);
+  const isContentValid = useMemo(() => content.trim().length > 0, [content]);
+  const isCategoryValid = useMemo(() => Boolean(category?.value), [category]);
 
-    setIsDisabled(!(isTitleValid && isContentValid));
-  }, [title, content]);
+  const isDisabled = useMemo(
+    () => !(isTitleValid && isContentValid && isCategoryValid) || isPending,
+    [isTitleValid, isContentValid, isCategoryValid, isPending],
+  );
 
   const handleGoBack = () => {
     navigate(-1);
   };
 
-  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleTitleChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.value.length <= LIMIT_SHORT_TEXT) {
       setTitle(e.target.value);
     }
   };
 
-  const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+  const handleContentChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     if (e.target.value.length <= LIMIT_LONG_TEXT) {
       setContent(e.target.value);
     }
   };
 
-  const handleCategory = () => {
-    // 카테고리 선택 기능 추후 구현
-    alert('카테고리 선택 기능은 추후 구현 예정입니다.');
-  };
+  const handleCategory = useCallback((option: CategoryType) => {
+    setCategory(option);
+  }, []);
 
   return (
     <div className={styles.container}>
@@ -105,16 +109,19 @@ const CommunityWrite = () => {
         <div className={styles.postHeader}>
           <div className={styles.postTitle}>
             <Title fontStyle="eb_md">{COMMUNITY_CONTENT.TITLE.HEADER}</Title>
-            <FilterDropDown optionTitle="보험 QnA">
-              <TextButton size="sm" color="black">
-                보험 QnA
-              </TextButton>
-              <TextButton size="sm" color="black">
-                정보공유
-              </TextButton>
-              <TextButton size="sm" color="black">
-                사담
-              </TextButton>
+            <FilterDropDown
+              optionTitle={category ? category.label : '카테고리 선택'}
+            >
+              {categoryOptions.map((option) => (
+                <TextButton
+                  key={option.value}
+                  size="sm"
+                  color={category?.value === option.value ? 'primary' : 'black'}
+                  onClick={() => handleCategory(option)}
+                >
+                  {option.label}
+                </TextButton>
+              ))}
             </FilterDropDown>
           </div>
           <Input

--- a/apps/client/src/widgets/community/components/filter-dropdown/filter-dropdown.tsx
+++ b/apps/client/src/widgets/community/components/filter-dropdown/filter-dropdown.tsx
@@ -15,14 +15,13 @@ const FilterDropDown = ({ optionTitle, children }: FilterDropDownProps) => {
   const [open, toggle] = useToggle(false);
 
   return (
-    <div className={styles.DropDownContainer}>
+    <div className={styles.DropDownContainer} onClick={toggle}>
       <div className={styles.DropDownTitle}>
         {optionTitle}
         <Icon
           name="caret_down_sm"
           rotate={open ? undefined : 180}
           className={styles.DropDownIcon}
-          onClick={toggle}
         />
       </div>
       {open && (

--- a/apps/client/src/widgets/community/configs/category-config.ts
+++ b/apps/client/src/widgets/community/configs/category-config.ts
@@ -1,0 +1,7 @@
+import { CategoryType } from '../types/category-type';
+
+export const categoryOptions: CategoryType[] = [
+  { label: '보험 QnA', value: 'QNA' },
+  { label: '정보공유', value: 'INFORMATION' },
+  { label: '사담', value: 'CONVERSATION' },
+];

--- a/apps/client/src/widgets/community/types/category-type.ts
+++ b/apps/client/src/widgets/community/types/category-type.ts
@@ -1,0 +1,6 @@
+export type CategoryValue = 'QNA' | 'INFORMATION' | 'CONVERSATION';
+
+export interface CategoryType {
+  label: string;
+  value: CategoryValue;
+}


### PR DESCRIPTION
## 📌 Summary

> - #416 

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

## 📚 Tasks

###  [ 글 작성 시 카테고리 기능 추가 ]

글 작성 시 **카테고리 기능**을 추가했어요. 
category 를 추가하면서 불필요한 useEffect 를 줄이고 useMemo 로 의존성 값이 변경 시에만 다시 Valid 를 계산하도록 리펙토링 했어요. 

category-type 은 커뮤니티에서만 쓰일 것 같아서 widgets/community/types 폴더에 따로 분리해두었어요. 

카테고리가 필수 값인지 (필수로 선택해야 게시물 작성이 가능한지) 여부가 궁금해서 스레드를 생성해두었어요. 
해당 부분 답변이 오면 추가로 수정될 부분이 생길 수 있습니다.

[➡️ 스레드 바로가기 
](https://bofit.slack.com/archives/C09E24P1MQC/p1758599968895599)

✅ [9/23 2:40pm] 정책 확정 되었습니다. 모든 값 valid 할 때만 올리기 및 수정 활성화 되도록 구현해두었습니다!


<!--
## 👀 To Reviewer

(기재 내용 없을 경우 섹션 삭제) 더 전달할 내용 혹은 리뷰에게 요청하는 내용을 작성해주세요.
-->

###  [ 드롭다운 컴포넌트 수정 건 ]

영상에서 보시면, 드롭다운에서 이 문구를 (title) 클릭했을 때는 드롭다운이 열리지 않고 오른쪽 아이콘을 누를 때만 열리는 상태였어요. 
저 아이콘만 드롭다운 오픈 기능이 있다는 것이 모바일 유저에게 불편할 수 있다고 생각했어요. 
그래서 드롭다운 컴포넌트 자체에 onClick 이 걸리도록 onClick 위치를 수정했습니다. 

**[ as - is ]** 

https://github.com/user-attachments/assets/638874d1-0fc9-415f-b65d-29020b3dee7d

**[ to - be ]**

https://github.com/user-attachments/assets/b9ea5ef2-eef9-4f76-9eee-e15e2a203691




## 📸 Screenshot


https://github.com/user-attachments/assets/dc58385b-a33b-4171-8843-d1db10fb1794

