### PR TITLE
Feat(client): 커뮤니티 개별글 좋아요 기능 추가

### DIFF
--- a/apps/client/src/shared/api/config/end-point.ts
+++ b/apps/client/src/shared/api/config/end-point.ts
@@ -15,6 +15,7 @@ export const END_POINT = {
       commentId: number,
       commentReplyId: number,
     ) => `posts/${postId}/comments/${commentId}/reply/${commentReplyId}`,
+    LIKE: (postId: string) => `posts/${postId}/likes`,
   },
   USER: {
     GET_USER_INFO: 'users/info',

--- a/apps/client/src/shared/api/config/end-point.ts
+++ b/apps/client/src/shared/api/config/end-point.ts
@@ -15,7 +15,8 @@ export const END_POINT = {
       commentId: number,
       commentReplyId: number,
     ) => `posts/${postId}/comments/${commentId}/reply/${commentReplyId}`,
-    LIKE: (postId: string) => `posts/${postId}/likes`,
+    POST_LIKE: (postId: string) => `posts/${postId}/likes`,
+    DELETE_LIKE: (postId: string) => `posts/${postId}/likes`,
   },
   USER: {
     GET_USER_INFO: 'users/info',

--- a/apps/client/src/shared/api/domain/community/queries.ts
+++ b/apps/client/src/shared/api/domain/community/queries.ts
@@ -204,14 +204,14 @@ export const COMMUNITY_MUTATION_OPTIONS = {
   },
 
   ADD_LIKE: (postId: string) => {
-    return mutationOptions<LikeAddResponse, Error, void>({
+    return mutationOptions({
       mutationKey: COMMUNITY_MUTATION_KEY.ADD_LIKE(postId),
       mutationFn: () => postLike(postId),
     });
   },
 
   DELETE_LIKE: (postId: string) => {
-    return mutationOptions<LikeDeleteResponse, Error, void>({
+    return mutationOptions({
       mutationKey: COMMUNITY_MUTATION_KEY.DELETE_LIKE(postId),
       mutationFn: () => deleteLike(postId),
     });

--- a/apps/client/src/shared/api/domain/community/queries.ts
+++ b/apps/client/src/shared/api/domain/community/queries.ts
@@ -329,7 +329,7 @@ export const deleteCommentReply = async (
  */
 export const postLike = async (postId: string): Promise<LikeAddResponse> => {
   const response = await api
-    .post(END_POINT.COMMUNITY.LIKE(postId))
+    .post(END_POINT.COMMUNITY.POST_LIKE(postId))
     .json<LikeAddResponse>();
   return response;
 };
@@ -343,7 +343,7 @@ export const deleteLike = async (
   postId: string,
 ): Promise<LikeDeleteResponse> => {
   const response = await api
-    .delete(END_POINT.COMMUNITY.LIKE(postId))
+    .delete(END_POINT.COMMUNITY.DELETE_LIKE(postId))
     .json<LikeDeleteResponse>();
   return response;
 };

--- a/apps/client/src/shared/api/domain/community/queries.ts
+++ b/apps/client/src/shared/api/domain/community/queries.ts
@@ -24,6 +24,8 @@ import {
   FeedResponse,
   FeedUpdateRequestBody,
   FeedUpdateResponse,
+  LikeAddResponse,
+  LikeDeleteResponse,
 } from '@shared/api/types/types';
 
 // =============================================================================
@@ -200,6 +202,20 @@ export const COMMUNITY_MUTATION_OPTIONS = {
         deleteCommentReply(postId, commentId, commentReplyId),
     });
   },
+
+  ADD_LIKE: (postId: string) => {
+    return mutationOptions<LikeAddResponse, Error, void>({
+      mutationKey: COMMUNITY_MUTATION_KEY.ADD_LIKE(postId),
+      mutationFn: () => postLike(postId),
+    });
+  },
+
+  DELETE_LIKE: (postId: string) => {
+    return mutationOptions<LikeDeleteResponse, Error, void>({
+      mutationKey: COMMUNITY_MUTATION_KEY.DELETE_LIKE(postId),
+      mutationFn: () => deleteLike(postId),
+    });
+  },
 };
 
 // =============================================================================
@@ -303,5 +319,31 @@ export const deleteCommentReply = async (
       `${END_POINT.COMMUNITY.DELETE_COMMENT_REPLY}/${postId}/comments/${commentId}/reply/${commentReplyId}`,
     )
     .json<CommentReplyDeleteResponse>();
+  return response;
+};
+
+/**
+ * 게시글에 좋아요를 추가합니다.
+ * @param postId - 좋아요를 누를 게시글 ID
+ * @returns 좋아요 생성 응답 데이터
+ */
+export const postLike = async (postId: string): Promise<LikeAddResponse> => {
+  const response = await api
+    .post(END_POINT.COMMUNITY.LIKE(postId))
+    .json<LikeAddResponse>();
+  return response;
+};
+
+/**
+ * 게시글의 좋아요를 취소합니다.
+ * @param postId - 좋아요를 취소할 게시글 ID
+ * @returns 좋아요 삭제 응답 데이터
+ */
+export const deleteLike = async (
+  postId: string,
+): Promise<LikeDeleteResponse> => {
+  const response = await api
+    .delete(END_POINT.COMMUNITY.LIKE(postId))
+    .json<LikeDeleteResponse>();
   return response;
 };

--- a/apps/client/src/shared/api/keys/query-key.ts
+++ b/apps/client/src/shared/api/keys/query-key.ts
@@ -66,6 +66,14 @@ export const COMMUNITY_MUTATION_KEY = {
     'reply',
     'delete',
   ],
+  ADD_LIKE: (postId: string) => [
+    ...COMMUNITY_QUERY_KEY.FEED_DETAIL(postId),
+    'add',
+  ],
+  DELETE_LIKE: (postId: string) => [
+    ...COMMUNITY_QUERY_KEY.FEED_DETAIL(postId),
+    'delete',
+  ],
 } as const;
 
 export const HOME_QUERY_KEY = {

--- a/apps/client/src/shared/api/types/types.ts
+++ b/apps/client/src/shared/api/types/types.ts
@@ -157,6 +157,18 @@ export type FeedPreviewResponse =
   paths['/posts']['get']['responses']['200']['content']['*/*']['data'];
 
 /**
+ * @description 좋아요 생성 성공 응답
+ */
+export type LikeAddResponse =
+  paths['/posts/{post-id}/likes']['post']['responses']['200']['content']['*/*']['data'];
+
+/**
+ * @description 좋아요 삭제 성공 응답
+ */
+export type LikeDeleteResponse =
+  paths['/posts/{post-id}/likes']['delete']['responses']['200']['content']['*/*']['data'];
+
+/**
  * @description 댓글 목록 조회 응답
  */
 export type CommentResponse =

--- a/apps/client/src/shared/api/types/types.ts
+++ b/apps/client/src/shared/api/types/types.ts
@@ -160,13 +160,13 @@ export type FeedPreviewResponse =
  * @description 좋아요 생성 성공 응답
  */
 export type LikeAddResponse =
-  paths['/posts/{post-id}/likes']['post']['responses']['200']['content']['*/*']['data'];
+  paths['/posts/{post-id}/likes']['post']['responses']['200']['content']['*/*'];
 
 /**
  * @description 좋아요 삭제 성공 응답
  */
 export type LikeDeleteResponse =
-  paths['/posts/{post-id}/likes']['delete']['responses']['200']['content']['*/*']['data'];
+  paths['/posts/{post-id}/likes']['delete']['responses']['200']['content']['*/*'];
 
 /**
  * @description 댓글 목록 조회 응답

--- a/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.css.ts
+++ b/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.css.ts
@@ -19,6 +19,10 @@ export const likeInfo = style({
   alignItems: 'center',
 });
 
+export const likeIcon = style({
+  cursor: 'pointer',
+});
+
 export const commentInfo = style({
   display: 'flex',
   gap: '0.4rem',

--- a/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.css.ts
+++ b/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.css.ts
@@ -25,7 +25,7 @@ export const commentInfo = style({
   alignItems: 'center',
 });
 
-export const commentNum = style({
+export const feedInfoNum = style({
   ...themeVars.fontStyles.head2_b_16,
   color: themeVars.color.gray800,
 });
@@ -34,7 +34,6 @@ export const commentContainer = style({
   display: 'flex',
   flexDirection: 'column',
   gap: '0.8rem',
-
   marginBottom: '9.6rem',
 });
 

--- a/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.css.ts
+++ b/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.css.ts
@@ -8,6 +8,17 @@ export const commentMapContainer = style({
   gap: '1.6rem',
 });
 
+export const feedInfo = style({
+  display: 'flex',
+  gap: '1rem',
+});
+
+export const likeInfo = style({
+  display: 'flex',
+  gap: '0.4rem',
+  alignItems: 'center',
+});
+
 export const commentInfo = style({
   display: 'flex',
   gap: '0.4rem',

--- a/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
@@ -57,23 +57,14 @@ const UserCommentList = ({
       <div className={styles.feedInfo}>
         <div className={styles.likeInfo}>
           {isLiked ? (
-            <>
-              <Icon
-                name="heart_fill"
-                width="2.4rem"
-                height="2.4rem"
-                color="error"
-              />
-            </>
+            <Icon
+              name="heart_fill"
+              width="2.4rem"
+              height="2.4rem"
+              color="error"
+            />
           ) : (
-            <>
-              <Icon
-                name="heart"
-                width="2.4rem"
-                height="2.4rem"
-                color="gray800"
-              />
-            </>
+            <Icon name="heart" width="2.4rem" height="2.4rem" color="gray800" />
           )}
           <p className={styles.feedInfoNum}>{feedDetailData?.likeCount}</p>
         </div>

--- a/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
@@ -43,6 +43,8 @@ const UserCommentList = ({
     }
   }, true);
 
+  const isLiked = feedDetailData?.likedByCurrentUser;
+
   if (!comments) {
     return null;
   }
@@ -54,7 +56,25 @@ const UserCommentList = ({
     <article className={styles.commentMapContainer}>
       <div className={styles.feedInfo}>
         <div className={styles.likeInfo}>
-          <Icon name="heart" width="2.4rem" height="2.4rem" color="gray800" />
+          {isLiked ? (
+            <>
+              <Icon
+                name="heart_fill"
+                width="2.4rem"
+                height="2.4rem"
+                color="error"
+              />
+            </>
+          ) : (
+            <>
+              <Icon
+                name="heart"
+                width="2.4rem"
+                height="2.4rem"
+                color="gray800"
+              />
+            </>
+          )}
           <p className={styles.feedInfoNum}>{feedDetailData?.likeCount}</p>
         </div>
         <div className={styles.commentInfo}>

--- a/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
@@ -54,7 +54,7 @@ const UserCommentList = ({
 
   const isLiked = feedDetailData?.likedByCurrentUser;
 
-  const { mutate: addLike } = useMutation<LikeAddResponse, Error, void>({
+  const { mutate: addLike } = useMutation({
     ...COMMUNITY_MUTATION_OPTIONS.ADD_LIKE(postId),
     onSuccess: () => {
       queryClient.invalidateQueries({
@@ -63,7 +63,7 @@ const UserCommentList = ({
     },
   });
 
-  const { mutate: deleteLike } = useMutation<LikeDeleteResponse, Error, void>({
+  const { mutate: deleteLike } = useMutation({
     ...COMMUNITY_MUTATION_OPTIONS.DELETE_LIKE(postId),
     onSuccess: () => {
       queryClient.invalidateQueries({

--- a/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
@@ -55,11 +55,11 @@ const UserCommentList = ({
       <div className={styles.feedInfo}>
         <div className={styles.likeInfo}>
           <Icon name="heart" width="2.4rem" height="2.4rem" color="gray800" />
-          <p className={styles.commentNum}>{feedDetailData?.likeCount}</p>
+          <p className={styles.feedInfoNum}>{feedDetailData?.likeCount}</p>
         </div>
         <div className={styles.commentInfo}>
           <Icon name="chat_square" width="2rem" height="2rem" color="gray800" />
-          <p className={styles.commentNum}>{feedDetailData?.commentCount}</p>
+          <p className={styles.feedInfoNum}>{feedDetailData?.commentCount}</p>
         </div>
       </div>
 

--- a/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
@@ -52,9 +52,15 @@ const UserCommentList = ({
 
   return (
     <article className={styles.commentMapContainer}>
-      <div className={styles.commentInfo}>
-        <Icon name="chat_square" width="2rem" height="2rem" color="gray800" />
-        <p className={styles.commentNum}>댓글 {feedDetailData?.commentCount}</p>
+      <div className={styles.feedInfo}>
+        <div className={styles.likeInfo}>
+          <Icon name="heart" width="2.4rem" height="2.4rem" color="gray800" />
+          <p className={styles.commentNum}>{feedDetailData?.likeCount}</p>
+        </div>
+        <div className={styles.commentInfo}>
+          <Icon name="chat_square" width="2rem" height="2rem" color="gray800" />
+          <p className={styles.commentNum}>{feedDetailData?.commentCount}</p>
+        </div>
       </div>
 
       <div className={styles.commentContainer}>

--- a/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
@@ -11,11 +11,7 @@ import {
   COMMUNITY_QUERY_OPTIONS,
 } from '@shared/api/domain/community/queries';
 import { COMMUNITY_QUERY_KEY } from '@shared/api/keys/query-key';
-import {
-  FeedDetailResponse,
-  LikeAddResponse,
-  LikeDeleteResponse,
-} from '@shared/api/types/types';
+import { FeedDetailResponse } from '@shared/api/types/types';
 import { useIntersectionObserver } from '@shared/hooks/use-intersection-observer';
 import { getTimeAgo } from '@shared/utils/get-time-ago';
 import { queryClient } from '@shared/utils/query-client';

--- a/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-list/user-comment-list.tsx
@@ -1,4 +1,4 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
 
 import { Icon } from '@bds/ui/icons';
 
@@ -6,10 +6,19 @@ import EmptyPlaceholder from '@widgets/community/components/empty-placeholder/em
 import UserComment from '@widgets/community/components/user-comment/user-comment';
 import { EMPTY_COMMENT } from '@widgets/community/constant/empty-content';
 
-import { COMMUNITY_QUERY_OPTIONS } from '@shared/api/domain/community/queries';
-import { FeedDetailResponse } from '@shared/api/types/types';
+import {
+  COMMUNITY_MUTATION_OPTIONS,
+  COMMUNITY_QUERY_OPTIONS,
+} from '@shared/api/domain/community/queries';
+import { COMMUNITY_QUERY_KEY } from '@shared/api/keys/query-key';
+import {
+  FeedDetailResponse,
+  LikeAddResponse,
+  LikeDeleteResponse,
+} from '@shared/api/types/types';
 import { useIntersectionObserver } from '@shared/hooks/use-intersection-observer';
 import { getTimeAgo } from '@shared/utils/get-time-ago';
+import { queryClient } from '@shared/utils/query-client';
 
 import * as styles from './user-comment-list.css';
 
@@ -45,6 +54,24 @@ const UserCommentList = ({
 
   const isLiked = feedDetailData?.likedByCurrentUser;
 
+  const { mutate: addLike } = useMutation<LikeAddResponse, Error, void>({
+    ...COMMUNITY_MUTATION_OPTIONS.ADD_LIKE(postId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: COMMUNITY_QUERY_KEY.FEED_DETAIL(postId),
+      });
+    },
+  });
+
+  const { mutate: deleteLike } = useMutation<LikeDeleteResponse, Error, void>({
+    ...COMMUNITY_MUTATION_OPTIONS.DELETE_LIKE(postId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: COMMUNITY_QUERY_KEY.FEED_DETAIL(postId),
+      });
+    },
+  });
+
   if (!comments) {
     return null;
   }
@@ -56,16 +83,25 @@ const UserCommentList = ({
     <article className={styles.commentMapContainer}>
       <div className={styles.feedInfo}>
         <div className={styles.likeInfo}>
-          {isLiked ? (
-            <Icon
-              name="heart_fill"
-              width="2.4rem"
-              height="2.4rem"
-              color="error"
-            />
-          ) : (
-            <Icon name="heart" width="2.4rem" height="2.4rem" color="gray800" />
-          )}
+          <div className={styles.likeIcon}>
+            {isLiked ? (
+              <Icon
+                name="heart_fill"
+                width="2.4rem"
+                height="2.4rem"
+                color="error"
+                onClick={() => deleteLike()}
+              />
+            ) : (
+              <Icon
+                name="heart"
+                width="2.4rem"
+                height="2.4rem"
+                color="gray800"
+                onClick={() => addLike()}
+              />
+            )}
+          </div>
           <p className={styles.feedInfoNum}>{feedDetailData?.likeCount}</p>
         </div>
         <div className={styles.commentInfo}>


### PR DESCRIPTION
## 📌 Summary

- close #434 

## 📚 Tasks

- 좋아요 생성(추가) api 연동
- 좋아요 삭제 api 연동


## 👀 To Reviewer
-  `isLiked` 변수를 두어 좋아요를 누른 상태인지 아닌지 확인하였고
- 좋아요를 누른 상태
  - heart_fill 아이콘
  - 클릭 시 좋아요 삭제되도록
 - 좋아요를 안 누른 상태
   - heart 아이콘 (비어있음)
   - 클릭 시 좋아요 추가되도록 하였습니다
<br>


- ~~mutation에 제네릭 타입 추가한 이유~~
  - ~~다른 mutation들과 달리 ADD_LIKE / DELETE_LIKE는 mutationFn에 인자가 없기 때문에 React Query가 반환 타입(TData)을 추론하지 못한다고 합니다.~~
  - ~~useMutation<LikeAddResponse, Error, void> 제네릭을 직접 지정해야 mutationFn의 반환값 타입(Promise<LikeAddResponse>)을 올바르게 인식한다고 하여 추가적으로 지정해두었습니다!~~
<!--
## 🕶️ Requirements Checklist
- [ ]

(기능 명세서상 내용을 복사해서 테스트해주세요)
-->


## 📸 Screenshot
<img width="400" alt="image" src="https://github.com/user-attachments/assets/7dd20da2-5a37-4d79-93a0-0291303a5fe8" />
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/9f2dc37e-88be-4839-adbf-ba0f7a55160b" />
