### PR TITLE
Feat(client): 커뮤니티 상세 페이지 댓글, 대댓글 수정, 작성 action/type 분리

### DIFF
--- a/apps/client/src/pages/community/community-detail.tsx
+++ b/apps/client/src/pages/community/community-detail.tsx
@@ -4,6 +4,7 @@ import { Navigation } from '@bds/ui';
 import { Icon } from '@bds/ui/icons';
 
 import DetailSection from '@widgets/community/components/detail-section/detail-section';
+import { InputModeContextProvider } from '@widgets/community/context/input-mode-context';
 
 import { useNavigateTo } from '@shared/hooks/use-navigate-to';
 import { routePath } from '@shared/router/path';
@@ -16,7 +17,7 @@ const CommunityDetail = () => {
   }
 
   return (
-    <>
+    <InputModeContextProvider postId={postId}>
       <Navigation
         title="커뮤니티"
         leftIcon={<Icon name="caret_left_lg" width="2.4rem" height="2.4rem" />}
@@ -26,7 +27,7 @@ const CommunityDetail = () => {
       />
 
       <DetailSection postId={postId} />
-    </>
+    </InputModeContextProvider>
   );
 };
 

--- a/apps/client/src/shared/api/domain/community/queries.ts
+++ b/apps/client/src/shared/api/domain/community/queries.ts
@@ -216,12 +216,13 @@ export const COMMUNITY_MUTATION_OPTIONS = {
 export const postComment = async (params: {
   postId: string;
   content: string;
+  imageUrls: string[];
 }): Promise<CommentPostResponse> => {
-  const { postId, content } = params;
+  const { postId, content, imageUrls } = params;
 
   return api
     .post(END_POINT.COMMUNITY.POST_COMMENTS(postId), {
-      json: { content },
+      json: { content, imageUrls },
     })
     .json<CommentPostResponse>();
 };

--- a/apps/client/src/shared/api/domain/community/queries.ts
+++ b/apps/client/src/shared/api/domain/community/queries.ts
@@ -301,7 +301,11 @@ export const deleteCommentReply = async (
 ): Promise<CommentReplyDeleteResponse> => {
   const response = await api
     .delete(
-      `${END_POINT.COMMUNITY.DELETE_COMMENT_REPLY}/${postId}/comments/${commentId}/reply/${commentReplyId}`,
+      END_POINT.COMMUNITY.DELETE_COMMENT_REPLY(
+        postId,
+        commentId,
+        commentReplyId,
+      ),
     )
     .json<CommentReplyDeleteResponse>();
   return response;

--- a/apps/client/src/widgets/community/components/comment-input-box/comment-input-box.tsx
+++ b/apps/client/src/widgets/community/components/comment-input-box/comment-input-box.tsx
@@ -12,6 +12,7 @@ interface CommentInputBoxProps {
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
   errorState?: boolean;
   onSubmit: () => void;
+  focusKey?: string;
 }
 
 const CommentInputBox = ({
@@ -19,6 +20,7 @@ const CommentInputBox = ({
   onChange,
   errorState,
   onSubmit,
+  focusKey,
 }: CommentInputBoxProps) => {
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.nativeEvent.isComposing) {
@@ -34,6 +36,8 @@ const CommentInputBox = ({
   return (
     <div className={styles.container}>
       <Input
+        key={focusKey}
+        autoFocus
         value={value}
         onChange={onChange}
         onKeyDown={handleKeyDown}

--- a/apps/client/src/widgets/community/components/comment-input-box/comment-input-box.tsx
+++ b/apps/client/src/widgets/community/components/comment-input-box/comment-input-box.tsx
@@ -1,9 +1,10 @@
-import { ChangeEvent, KeyboardEvent } from 'react';
+import { ChangeEvent, KeyboardEvent, useRef } from 'react';
 
 import { Input } from '@bds/ui';
 import { Icon } from '@bds/ui/icons';
 
 import { PLACEHOLDER } from '@widgets/community/constant/input-placeholder';
+import { useChangeInputMode } from '@widgets/community/context/input-mode-context';
 
 import * as styles from './comment-input-box.css';
 
@@ -22,6 +23,9 @@ const CommentInputBox = ({
   onSubmit,
   focusKey,
 }: CommentInputBoxProps) => {
+  const { mode, dispatch } = useChangeInputMode();
+  const skipResetRef = useRef(false);
+
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.nativeEvent.isComposing) {
       return;
@@ -29,7 +33,17 @@ const CommentInputBox = ({
 
     if (e.key === 'Enter') {
       e.preventDefault();
+      skipResetRef.current = true;
       onSubmit();
+    }
+  };
+
+  const handleBlur = () => {
+    if (skipResetRef.current) {
+      return;
+    }
+    if (mode.type === 'reply' && mode.action === 'create') {
+      dispatch({ type: 'RESET' });
     }
   };
 
@@ -41,6 +55,7 @@ const CommentInputBox = ({
         value={value}
         onChange={onChange}
         onKeyDown={handleKeyDown}
+        onBlur={handleBlur}
         bgColor="white"
         placeholder={PLACEHOLDER.COMMENT}
         errorState={errorState}

--- a/apps/client/src/widgets/community/components/detail-section/detail-section.tsx
+++ b/apps/client/src/widgets/community/components/detail-section/detail-section.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import CommentInputBox from '@widgets/community/components/comment-input-box/comment-input-box';
@@ -75,7 +74,7 @@ const DetailSection = ({ postId }: DetailSectionProps) => {
     }
   };
 
-  const focusKey = useMemo(() => JSON.stringify(mode), [mode]);
+  const focusKey = `${mode.type}-${mode.action}-${'commentId' in mode ? mode.commentId : ''}`;
 
   return (
     <>

--- a/apps/client/src/widgets/community/components/detail-section/detail-section.tsx
+++ b/apps/client/src/widgets/community/components/detail-section/detail-section.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import CommentInputBox from '@widgets/community/components/comment-input-box/comment-input-box';
 import FeedContent from '@widgets/community/components/feed-content/feed-content';
 import { useChangeInputMode } from '@widgets/community/context/input-mode-context';
-import { useInputBox } from '@widgets/community/hooks/use-input-box';
+import { useControlledInputBox } from '@widgets/community/hooks/use-controll-input-box';
 
 import { COMMUNITY_MUTATION_OPTIONS } from '@shared/api/domain/community/queries';
 import { COMMUNITY_QUERY_KEY } from '@shared/api/keys/query-key';
@@ -16,7 +16,7 @@ interface DetailSectionProps {
 
 const DetailSection = ({ postId }: DetailSectionProps) => {
   const { mode } = useChangeInputMode();
-  const { content, handleChange, reset } = useInputBox(mode);
+  const { content, handleChange, reset } = useControlledInputBox(mode);
   const { isErrorState } = useLimitedInput(LIMIT_MEDIUM_TEXT, content.length);
 
   const queryClient = useQueryClient();

--- a/apps/client/src/widgets/community/components/detail-section/detail-section.tsx
+++ b/apps/client/src/widgets/community/components/detail-section/detail-section.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import CommentInputBox from '@widgets/community/components/comment-input-box/comment-input-box';
@@ -67,6 +68,8 @@ const DetailSection = ({ postId }: DetailSectionProps) => {
     }
   };
 
+  const focusKey = useMemo(() => JSON.stringify(mode), [mode]);
+
   return (
     <>
       <FeedContent postId={postId} />
@@ -75,6 +78,7 @@ const DetailSection = ({ postId }: DetailSectionProps) => {
         onChange={handleChange}
         errorState={isErrorState}
         onSubmit={handleSubmitComment}
+        focusKey={focusKey}
       />
     </>
   );

--- a/apps/client/src/widgets/community/components/detail-section/detail-section.tsx
+++ b/apps/client/src/widgets/community/components/detail-section/detail-section.tsx
@@ -39,9 +39,16 @@ const DetailSection = ({ postId }: DetailSectionProps) => {
       return;
     }
 
+    // 아직 이미지 추가가 없어서 주석처리 const imageUrls = imageUrls?.length ? imageUrls : [];
+    // 임시
+    const imageUrls: string[] = [];
+
     switch (`${mode.type}-${mode.action}` as const) {
       case 'comment-create':
-        createCommentMutate({ postId, content: trimmed }, { onSuccess: reset });
+        createCommentMutate(
+          { postId, content: trimmed, imageUrls },
+          { onSuccess: reset },
+        );
         break;
 
       // @ TODO: 댓글 수정, 대댓글 작성, 대댓글 수정 api 연동 필요.

--- a/apps/client/src/widgets/community/components/detail-section/detail-section.tsx
+++ b/apps/client/src/widgets/community/components/detail-section/detail-section.tsx
@@ -1,15 +1,13 @@
-import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import CommentInputBox from '@widgets/community/components/comment-input-box/comment-input-box';
 import FeedContent from '@widgets/community/components/feed-content/feed-content';
+import { useChangeInputMode } from '@widgets/community/context/input-mode-context';
+import { useInputBox } from '@widgets/community/hooks/use-input-box';
 
 import { COMMUNITY_MUTATION_OPTIONS } from '@shared/api/domain/community/queries';
 import { COMMUNITY_QUERY_KEY } from '@shared/api/keys/query-key';
-import {
-  LIMIT_MEDIUM_TEXT,
-  LIMIT_SHORT_TEXT,
-} from '@shared/constants/text-limits';
+import { LIMIT_MEDIUM_TEXT } from '@shared/constants/text-limits';
 import { useLimitedInput } from '@shared/hooks/use-limited-input';
 
 interface DetailSectionProps {
@@ -17,8 +15,10 @@ interface DetailSectionProps {
 }
 
 const DetailSection = ({ postId }: DetailSectionProps) => {
-  const [content, setContent] = useState('');
+  const { mode } = useChangeInputMode();
+  const { content, handleChange, reset } = useInputBox(mode);
   const { isErrorState } = useLimitedInput(LIMIT_MEDIUM_TEXT, content.length);
+
   const queryClient = useQueryClient();
   const { mutate: createCommentMutate } = useMutation({
     ...COMMUNITY_MUTATION_OPTIONS.POST_COMMENT(),
@@ -32,35 +32,49 @@ const DetailSection = ({ postId }: DetailSectionProps) => {
     },
   });
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.value.length <= LIMIT_SHORT_TEXT) {
-      setContent(e.target.value);
-    }
-  };
-
-  const onSubmitComment = () => {
-    if (!content.trim()) {
+  const handleSubmitComment = () => {
+    const trimmed = content.trim();
+    if (!trimmed) {
       return;
     }
-    createCommentMutate(
-      { postId, content: content.trim() },
-      {
-        onSuccess: () => {
-          setContent('');
-        },
-      },
-    );
+
+    switch (`${mode.type}-${mode.action}` as const) {
+      case 'comment-create':
+        createCommentMutate({ postId, content: trimmed }, { onSuccess: reset });
+        break;
+
+      // @ TODO: 댓글 수정, 대댓글 작성, 대댓글 수정 api 연동 필요.
+      // case 'comment-edit':
+      //   updateCommentMutate({
+      //     postId,
+      //     commentId: mode.commentId,
+      //     content: trimmed,
+      //   });
+      //   break;
+      // case 'reply-create':
+      //   createReplyMutate(
+      //     { postId, parentCommentId: mode.parentCommentId, content: trimmed },
+      //     { onSuccess: reset },
+      //   );
+      //   break;
+      // case 'reply-edit':
+      //   updateReplyMutate({
+      //     postId,
+      //     commentId: mode.commentId,
+      //     content: trimmed,
+      //   });
+      //   break;
+    }
   };
 
   return (
     <>
       <FeedContent postId={postId} />
-
       <CommentInputBox
         value={content}
         onChange={handleChange}
         errorState={isErrorState}
-        onSubmit={onSubmitComment}
+        onSubmit={handleSubmitComment}
       />
     </>
   );

--- a/apps/client/src/widgets/community/components/user-comment-info/user-comment-info.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-info/user-comment-info.tsx
@@ -2,6 +2,7 @@ import { Avatar, TextButton } from '@bds/ui';
 import { Icon } from '@bds/ui/icons';
 
 import FilterDropDown from '@widgets/community/components/filter-dropdown/filter-dropdown';
+import { useChangeInputMode } from '@widgets/community/context/input-mode-context';
 import { CommentType } from '@widgets/community/types/community-comment.type.ts';
 
 import { Image } from '@shared/types/type.ts';
@@ -11,9 +12,14 @@ import * as styles from './user-comment-info.css';
 interface UserCommentInfoProps {
   comment: CommentType;
   images?: Image[];
+  commentId: number;
 }
 
-const UserCommentInfo = ({ comment, images }: UserCommentInfoProps) => {
+const UserCommentInfo = ({
+  comment,
+  images,
+  commentId,
+}: UserCommentInfoProps) => {
   const {
     content,
     writerNickName,
@@ -22,9 +28,18 @@ const UserCommentInfo = ({ comment, images }: UserCommentInfoProps) => {
     isCommentOwner,
     onDeleteClick,
   } = comment;
+  const { dispatch } = useChangeInputMode();
 
   const commentImages =
     images?.filter(({ imageUrl }) => imageUrl?.trim()) ?? [];
+
+  const handleCommentEdit = () => {
+    dispatch({
+      type: 'COMMENT_EDIT',
+      commentId,
+      initialContent: content ?? '',
+    });
+  };
 
   return (
     <div className={styles.container}>
@@ -43,13 +58,7 @@ const UserCommentInfo = ({ comment, images }: UserCommentInfoProps) => {
                 rightIcon={<Icon name="more" />}
                 isIconRotate={false}
               >
-                <TextButton
-                  size="sm"
-                  color="black"
-                  onClick={() => {
-                    // @TODO: 댓글 수정 API 연동
-                  }}
-                >
+                <TextButton size="sm" color="black" onClick={handleCommentEdit}>
                   수정
                 </TextButton>
                 <TextButton size="sm" color="error" onClick={onDeleteClick}>

--- a/apps/client/src/widgets/community/components/user-comment-reply/user-comment-reply.css.ts
+++ b/apps/client/src/widgets/community/components/user-comment-reply/user-comment-reply.css.ts
@@ -70,3 +70,9 @@ export const replyImage = style({
   width: '100%',
   borderRadius: '1.2rem',
 });
+
+export const editingReply = style({
+  ...themeVars.fontStyles.body1_m_12,
+  color: themeVars.color.gray800,
+  padding: '0 3.4rem',
+});

--- a/apps/client/src/widgets/community/components/user-comment-reply/user-comment-reply.css.ts
+++ b/apps/client/src/widgets/community/components/user-comment-reply/user-comment-reply.css.ts
@@ -13,7 +13,7 @@ export const container = recipe({
   variants: {
     isEditingReply: {
       true: {
-        borderRadius: '1.2rem',
+        borderRadius: '12px',
         border: `1px solid ${themeVars.color.primary500}`,
       },
       false: {},

--- a/apps/client/src/widgets/community/components/user-comment-reply/user-comment-reply.css.ts
+++ b/apps/client/src/widgets/community/components/user-comment-reply/user-comment-reply.css.ts
@@ -7,7 +7,7 @@ export const container = recipe({
   base: {
     display: 'flex',
     flexDirection: 'column',
-    padding: '0.8rem 0',
+    padding: '1.2rem 0',
     gap: '0.4rem',
   },
   variants: {

--- a/apps/client/src/widgets/community/components/user-comment-reply/user-comment-reply.css.ts
+++ b/apps/client/src/widgets/community/components/user-comment-reply/user-comment-reply.css.ts
@@ -1,12 +1,24 @@
 import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
 
 import { themeVars } from '@bds/ui/styles';
 
-export const container = style({
-  display: 'flex',
-  flexDirection: 'column',
-  padding: '0.8rem 0',
-  gap: '0.4rem',
+export const container = recipe({
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    padding: '0.8rem 0',
+    gap: '0.4rem',
+  },
+  variants: {
+    isEditingReply: {
+      true: {
+        borderRadius: '1.2rem',
+        border: `1px solid ${themeVars.color.primary500}`,
+      },
+      false: {},
+    },
+  },
 });
 
 export const userInfoContainer = style({

--- a/apps/client/src/widgets/community/components/user-comment-reply/user-comment-reply.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-reply/user-comment-reply.tsx
@@ -29,7 +29,7 @@ const UserCommentReply = ({
   onClickDelete,
   isReplyOwner,
 }: UserCommentReplyProps) => {
-  const { dispatch } = useChangeInputMode();
+  const { mode, dispatch } = useChangeInputMode();
 
   const handleEditReply = () => {
     dispatch({
@@ -39,8 +39,13 @@ const UserCommentReply = ({
     });
   };
 
+  const isEditingReply =
+    mode.type === 'reply' &&
+    mode.action === 'edit' &&
+    mode.commentId === commentReplyId;
+
   return (
-    <div className={styles.container}>
+    <div className={styles.container({ isEditingReply })}>
       <div className={styles.userInfoContainer}>
         <div className={styles.leftContainer}>
           <Icon name="recomment_line" width="2rem" height="2rem" />

--- a/apps/client/src/widgets/community/components/user-comment-reply/user-comment-reply.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-reply/user-comment-reply.tsx
@@ -2,6 +2,7 @@ import { Avatar, TextButton } from '@bds/ui';
 import { Icon } from '@bds/ui/icons';
 
 import FilterDropDown from '@widgets/community/components/filter-dropdown/filter-dropdown';
+import { useChangeInputMode } from '@widgets/community/context/input-mode-context';
 
 import { Image } from '@shared/types/type';
 
@@ -28,6 +29,16 @@ const UserCommentReply = ({
   onClickDelete,
   isReplyOwner,
 }: UserCommentReplyProps) => {
+  const { dispatch } = useChangeInputMode();
+
+  const handleEditReply = () => {
+    dispatch({
+      type: 'REPLY_EDIT',
+      commentId: commentReplyId,
+      initialContent: content ?? '',
+    });
+  };
+
   return (
     <div className={styles.container}>
       <div className={styles.userInfoContainer}>
@@ -47,13 +58,7 @@ const UserCommentReply = ({
               rightIcon={<Icon name="more" />}
               isIconRotate={false}
             >
-              <TextButton
-                size="sm"
-                color="black"
-                onClick={() => {
-                  // @TODO: 댓글 수정 API 연동
-                }}
-              >
+              <TextButton size="sm" color="black" onClick={handleEditReply}>
                 수정
               </TextButton>
               <TextButton

--- a/apps/client/src/widgets/community/components/user-comment-reply/user-comment-reply.tsx
+++ b/apps/client/src/widgets/community/components/user-comment-reply/user-comment-reply.tsx
@@ -92,6 +92,9 @@ const UserCommentReply = ({
           ))}
         </div>
       )}
+      {isEditingReply ? (
+        <p className={styles.editingReply}>수정 중...</p>
+      ) : null}
     </div>
   );
 };

--- a/apps/client/src/widgets/community/components/user-comment/user-comment.css.ts
+++ b/apps/client/src/widgets/community/components/user-comment/user-comment.css.ts
@@ -14,14 +14,24 @@ export const root = style({
   position: 'relative',
 });
 
-export const userInfoContainer = style({
-  display: 'flex',
-  flexDirection: 'column',
-  padding: '1.2rem 1.6rem',
-  borderRadius: '12px',
-  width: '100%',
-  gap: '0.4rem',
-  backgroundColor: themeVars.color.whiteBackground,
+export const userInfoContainer = recipe({
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    padding: '1.2rem 1.6rem',
+    borderRadius: '12px',
+    width: '100%',
+    gap: '0.4rem',
+    backgroundColor: themeVars.color.whiteBackground,
+  },
+  variants: {
+    isEditingComment: {
+      true: {
+        border: `1px solid ${themeVars.color.primary500}`,
+      },
+      false: {},
+    },
+  },
 });
 
 export const replyButtonContainer = style({

--- a/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
+++ b/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
@@ -5,6 +5,7 @@ import { Icon } from '@bds/ui/icons';
 
 import UserCommentInfo from '@widgets/community/components/user-comment-info/user-comment-info';
 import UserCommentReply from '@widgets/community/components/user-comment-reply/user-comment-reply';
+import { useChangeInputMode } from '@widgets/community/context/input-mode-context';
 import { CommentType } from '@widgets/community/types/community-comment.type.ts';
 
 import { COMMUNITY_QUERY_OPTIONS } from '@shared/api/domain/community/queries';
@@ -34,6 +35,8 @@ const UserComment = ({
   onCommentReplyDeleteClick,
   commentOwnerId,
 }: UserCommentProps) => {
+  const { dispatch } = useChangeInputMode();
+
   const [isRepliesOpen, toggleReplies] = useToggle();
 
   const {
@@ -57,13 +60,22 @@ const UserComment = ({
 
   const allCommentReply =
     commentReply.pages.flatMap((page) => page?.data?.content ?? []) ?? [];
+
+  const handleSubmitReply = () => {
+    dispatch({ type: 'REPLY_CREATE', parentCommentId: commentId });
+  };
+
   return (
     <div className={styles.root}>
       <div className={styles.container}>
         <div className={styles.userInfoContainer}>
-          <UserCommentInfo comment={comment} images={images} />
+          <UserCommentInfo
+            comment={comment}
+            images={images}
+            commentId={commentId}
+          />
           <p>
-            <TextButton size="xs" color="black">
+            <TextButton size="xs" color="black" onClick={handleSubmitReply}>
               답글 달기
             </TextButton>
           </p>

--- a/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
+++ b/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
@@ -35,7 +35,7 @@ const UserComment = ({
   onCommentReplyDeleteClick,
   commentOwnerId,
 }: UserCommentProps) => {
-  const { dispatch } = useChangeInputMode();
+  const { mode, dispatch } = useChangeInputMode();
 
   const [isRepliesOpen, toggleReplies] = useToggle();
 
@@ -65,10 +65,15 @@ const UserComment = ({
     dispatch({ type: 'REPLY_CREATE', parentCommentId: commentId });
   };
 
+  const isEditingComment =
+    mode.type === 'comment' &&
+    mode.action === 'edit' &&
+    mode.commentId === commentId;
+
   return (
     <div className={styles.root}>
       <div className={styles.container}>
-        <div className={styles.userInfoContainer}>
+        <div className={styles.userInfoContainer({ isEditingComment })}>
           <UserCommentInfo
             comment={comment}
             images={images}

--- a/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
+++ b/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
@@ -45,7 +45,7 @@ const UserComment = ({
     isFetchingNextPage,
   } = useInfiniteQuery({
     ...COMMUNITY_QUERY_OPTIONS.COMMENT_REPLY(postId, commentId),
-    enabled: Boolean(isRepliesOpen && commentId != null),
+    enabled: isRepliesOpen && !!commentId,
     retry: false,
   });
 

--- a/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
+++ b/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
@@ -36,7 +36,6 @@ const UserComment = ({
   commentOwnerId,
 }: UserCommentProps) => {
   const { mode, dispatch } = useChangeInputMode();
-
   const [isRepliesOpen, toggleReplies] = useToggle();
 
   const {
@@ -46,6 +45,8 @@ const UserComment = ({
     isFetchingNextPage,
   } = useInfiniteQuery({
     ...COMMUNITY_QUERY_OPTIONS.COMMENT_REPLY(postId, commentId),
+    enabled: Boolean(isRepliesOpen && commentId != null),
+    retry: false,
   });
 
   const commentsObserverRef = useIntersectionObserver(() => {
@@ -54,12 +55,8 @@ const UserComment = ({
     }
   }, true);
 
-  if (!commentReply) {
-    return null;
-  }
-
   const allCommentReply =
-    commentReply.pages.flatMap((page) => page?.data?.content ?? []) ?? [];
+    commentReply?.pages.flatMap((page) => page?.data?.content ?? []) ?? [];
 
   const handleSubmitReply = () => {
     dispatch({ type: 'REPLY_CREATE', parentCommentId: commentId });

--- a/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
+++ b/apps/client/src/widgets/community/components/user-comment/user-comment.tsx
@@ -81,7 +81,7 @@ const UserComment = ({
           />
           <p>
             <TextButton size="xs" color="black" onClick={handleSubmitReply}>
-              답글 달기
+              {isEditingComment ? '수정 중...' : '답글 달기'}
             </TextButton>
           </p>
         </div>

--- a/apps/client/src/widgets/community/context/input-mode-context.tsx
+++ b/apps/client/src/widgets/community/context/input-mode-context.tsx
@@ -1,0 +1,61 @@
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+} from 'react';
+
+import { createInputModeReducer } from '@widgets/community/hooks/create-input-mode-reducer';
+import {
+  InputBoxMode,
+  ReducerAction,
+} from '@widgets/community/types/input-box-type';
+
+interface InputModeContextValue {
+  mode: InputBoxMode;
+  dispatch: React.Dispatch<ReducerAction>;
+}
+
+const InputModeContext = createContext<InputModeContextValue | null>(null);
+
+export const InputModeContextProvider = ({
+  postId,
+  children,
+}: {
+  postId: string;
+  children: ReactNode;
+}) => {
+  const reducer: React.Reducer<InputBoxMode, ReducerAction> = (
+    prev,
+    action,
+  ) => {
+    console.log({ prev, action });
+    return createInputModeReducer({ postId, _prev: prev, action });
+  };
+
+  const [mode, dispatch] = useReducer(reducer, {
+    type: 'comment',
+    action: 'create',
+    postId,
+  } as const);
+
+  useEffect(() => {
+    dispatch({ type: 'RESET' });
+  }, [postId]);
+  const value = useMemo(() => ({ mode, dispatch }), [mode]);
+  return (
+    <InputModeContext.Provider value={value}>
+      {children}
+    </InputModeContext.Provider>
+  );
+};
+
+export const useChangeInputMode = () => {
+  const mode = useContext(InputModeContext);
+  if (!mode) {
+    throw new Error('InputModeContextProvider 안에서 사용하세요.');
+  }
+  return mode;
+};

--- a/apps/client/src/widgets/community/context/input-mode-context.tsx
+++ b/apps/client/src/widgets/community/context/input-mode-context.tsx
@@ -1,5 +1,6 @@
 import {
   createContext,
+  Dispatch,
   ReactNode,
   useContext,
   useEffect,
@@ -15,7 +16,7 @@ import {
 
 interface InputModeContextValue {
   mode: InputBoxMode;
-  dispatch: React.Dispatch<ReducerAction>;
+  dispatch: Dispatch<ReducerAction>;
 }
 
 const InputModeContext = createContext<InputModeContextValue | null>(null);

--- a/apps/client/src/widgets/community/context/input-mode-context.tsx
+++ b/apps/client/src/widgets/community/context/input-mode-context.tsx
@@ -31,7 +31,6 @@ export const InputModeContextProvider = ({
     prev,
     action,
   ) => {
-    console.log({ prev, action });
     return createInputModeReducer({ postId, _prev: prev, action });
   };
 

--- a/apps/client/src/widgets/community/hooks/create-input-mode-reducer.ts
+++ b/apps/client/src/widgets/community/hooks/create-input-mode-reducer.ts
@@ -1,0 +1,44 @@
+import type {
+  InputBoxMode,
+  ReducerAction,
+} from '@widgets/community/types/input-box-type';
+
+interface ComposeModeReducerType {
+  postId: string;
+  _prev: InputBoxMode;
+  action: ReducerAction;
+}
+
+export const createInputModeReducer = ({
+  postId,
+  action,
+}: ComposeModeReducerType) => {
+  switch (action.type) {
+    case 'COMMENT_EDIT':
+      return {
+        type: 'comment',
+        action: 'edit',
+        postId,
+        commentId: action.commentId,
+        initialContent: action.initialContent,
+      } as const;
+    case 'REPLY_CREATE':
+      return {
+        type: 'reply',
+        action: 'create',
+        postId,
+        parentCommentId: action.parentCommentId,
+      } as const;
+    case 'REPLY_EDIT':
+      return {
+        type: 'reply',
+        action: 'edit',
+        postId,
+        commentId: action.commentId,
+        initialContent: action.initialContent,
+      } as const;
+    case 'RESET':
+    default:
+      return { type: 'comment', action: 'create', postId } as const;
+  }
+};

--- a/apps/client/src/widgets/community/hooks/use-controll-input-box.ts
+++ b/apps/client/src/widgets/community/hooks/use-controll-input-box.ts
@@ -4,7 +4,7 @@ import { InputBoxMode } from '@widgets/community/types/input-box-type';
 
 import { LIMIT_SHORT_TEXT } from '@shared/constants/text-limits';
 
-export const useInputBox = (mode: InputBoxMode) => {
+export const useControlledInputBox = (mode: InputBoxMode) => {
   const [content, setContent] = useState(
     'initialContent' in mode ? mode.initialContent : '',
   );

--- a/apps/client/src/widgets/community/hooks/use-controll-input-box.ts
+++ b/apps/client/src/widgets/community/hooks/use-controll-input-box.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { InputBoxMode } from '@widgets/community/types/input-box-type';
 
@@ -13,16 +13,16 @@ export const useControlledInputBox = (mode: InputBoxMode) => {
     setContent('initialContent' in mode ? mode.initialContent : '');
   }, [mode]);
 
-  const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const next = e.target.value;
     if (next.length <= LIMIT_SHORT_TEXT) {
       setContent(next);
     }
-  }, []);
+  };
 
-  const reset = useCallback(() => {
+  const reset = () => {
     setContent('initialContent' in mode ? mode.initialContent : '');
-  }, [mode]);
+  };
 
   return { content, handleChange, reset };
 };

--- a/apps/client/src/widgets/community/hooks/use-input-box.ts
+++ b/apps/client/src/widgets/community/hooks/use-input-box.ts
@@ -1,0 +1,28 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { InputBoxMode } from '@widgets/community/types/input-box-type';
+
+import { LIMIT_SHORT_TEXT } from '@shared/constants/text-limits';
+
+export const useInputBox = (mode: InputBoxMode) => {
+  const [content, setContent] = useState(
+    'initialContent' in mode ? mode.initialContent : '',
+  );
+
+  useEffect(() => {
+    setContent('initialContent' in mode ? mode.initialContent : '');
+  }, [mode]);
+
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const next = e.target.value;
+    if (next.length <= LIMIT_SHORT_TEXT) {
+      setContent(next);
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    setContent('initialContent' in mode ? mode.initialContent : '');
+  }, [mode]);
+
+  return { content, handleChange, reset };
+};

--- a/apps/client/src/widgets/community/types/input-box-type.ts
+++ b/apps/client/src/widgets/community/types/input-box-type.ts
@@ -1,0 +1,23 @@
+export type InputBoxMode =
+  | { type: 'comment'; action: 'create'; postId: string }
+  | {
+      type: 'comment';
+      action: 'edit';
+      postId: string;
+      commentId: number;
+      initialContent: string;
+    }
+  | { type: 'reply'; action: 'create'; postId: string; parentCommentId: number }
+  | {
+      type: 'reply';
+      action: 'edit';
+      postId: string;
+      commentId: number;
+      initialContent: string;
+    };
+
+export type ReducerAction =
+  | { type: 'COMMENT_EDIT'; commentId: number; initialContent: string }
+  | { type: 'REPLY_CREATE'; parentCommentId: number }
+  | { type: 'REPLY_EDIT'; commentId: number; initialContent: string }
+  | { type: 'RESET' };


### PR DESCRIPTION
## 📌 Summary

> - #447 

## 📚 Tasks
구현 설명에 앞서 Flow를 먼저 설명드릴게요.
```tsx
<InputModeContextProvider postId={postId}>
  <Navigation ... />
  <DetailSection postId={postId} />
</InputModeContextProvider>
```
이처럼 community-detail 페이지의 InputBox의 모드 (state)를 전역으로 관리할 수 있도록 Context로 감쌌어요. 이는 댓글과 대댓글 컴포넌트가 모두 동일한 mode 상태를 공유하기 위함이에요. 따라서 댓글이나 대댓글의 `수정하기` 버튼을 클릭하면 InputBox가 수정 모드로 전환되도록 구현했어요.

<details>
<summary>contextAPI를 사용하지 않았을 때</summary>

```tsx
onCommentEditClick={(commentId, initialContent) =>
          dispatchComposer({ type: 'COMMENT_EDIT', commentId, initialContent })
        }
        onReplyCreateClick={(parentCommentId) =>
          dispatchComposer({ type: 'REPLY_CREATE', parentCommentId })
        }
        onReplyEditClick={(commentId, initialContent) =>
          dispatchComposer({ type: 'REPLY_EDIT', commentId, initialContent })
        }
        onCancelInputMode={() => dispatchComposer({ type: 'RESET' })}
```
이런식으로 props도 많아지고 각 컴포넌트 연결에 불편할 것 같다고 생각했어요.
</details>

여기서 InputModeContextProvider가 어떤 역할을 하냐면
`const [mode, dispatch] = useReducer(reducer, { type: 'comment', action: 'create', postId });`
이처럼 각 액션에 따라 mode 형태를 업데이트 하도록 구현했어요.
이를 통해 댓글이나 대댓글 컴포넌트 어디서든 `useChangeInputMode()`를 통해 입력 모드 상태에 접근하고 변경할 수 있도록 했어요.

상태를 예를 들면
```tsx
{
  type: 'reply',          // comment(댓글) | reply(대댓글)
  action: 'edit',         // create(작성) | edit(수정)
  postId: '123',         // 게시물 ID
  commentId: 10,          // 수정할 댓글 ID
  initialContent: '기존 내용'
}
```
이처럼 상태를 관리할 수 있도록 했습니다.

mode는 DetailSection 컴포넌트에서 사용하도록 했어요. 이 컴포넌트에 입력창이 포함되어 있고 `handleSubmitComment()` 내부에서 mode에 따라 어떤 Mutation을 실행할지 분기하기 때문이에요.

기존에는 입력창 유효성(30자 제한, 초과 시 테두리 색상 변경 등)을 `handleChange` 함수 내부에서 직접 관리하고 있었어요.
이를 로직과 모드 변경 시 입력창 내용을 갱신하거나 reset하는 로직을 `useControlledInputBox` 훅으로 분리해 관리하도록 변경했어요.

수정모드가 필요한 곳은 UserComment ( 댓글 컴포넌트 ) 그리고 UserCommentReply ( 대댓글 컴포넌트) 두 곳이에요. 각 컴포넌트에서 위에서 설명한 mode를 불러서 모드를 수정하도록 했습니다.

```tsx
import { useChangeInputMode } from '@widgets/community/context/input-mode-context';

const { mode, dispatch } = useChangeInputMode();

const handleSubmitReply = () => {
    dispatch({ type: 'REPLY_CREATE', parentCommentId: commentId });
  };
```
처음 호출 시 댓글 컴포넌트는 기본적으로 댓글 작성 모드, 대댓글 컴포넌트는 답글 작성 혹은 수정 모드로 진입하도록 설정했어요. ( 답글 작성 버튼과 수정 버튼이 각각 다른 위치에서 호출되기 때문이에요)

커뮤니티 상세 페이지에서 댓글/대댓글의 작성, 수정 플로우를 type과 action으로 분리하고, 입력창을 공용으로 사용하도록 구현했어요.

댓글과 대댓글 모두 작성과 수정이 존재하기 때문에 이 두 요소를 (type, action)으로 분리해 하나의 구조로 관리하면 훨씬 단순하고 재사용성이 높다고 판단했어요.

그래서 `create-input-mode-reducer.ts`파일에서 다음과 같이 `COMMENT_EDIT / REPLY_CREATE / REPLY_EDIT / RESET` 네 가지 액션으로 분기했어요. 

```tsx
export type InputBoxMode =
  | { type: 'comment'; action: 'create'; postId: string }
  | { type: 'comment'; action: 'edit'; postId: string; commentId: number; initialContent: string }
  | { type: 'reply';   action: 'create'; postId: string; parentCommentId: number }
  | { type: 'reply';   action: 'edit'; postId: string; commentId: number; initialContent: string };

export type ReducerAction =
  | { type: 'COMMENT_EDIT'; commentId: number; initialContent: string }
  | { type: 'REPLY_CREATE'; parentCommentId: number }
  | { type: 'REPLY_EDIT';   commentId: number; initialContent: string }
  | { type: 'RESET' };
```
이 구조를 통해 댓글이든 대댓글이든 동일한 입력창에서 모드 전환만으로 작성과 수정을 처리할 수 있도록 했습니다.

## 👀 To Reviewer
댓글 모드가 잘 변하는지 확인하려면
`DetailSection` 컴포넌트에서
```tsx
 useEffect(() => {
    console.log('[현재 입력 모드]', mode);
  }, [mode]);
```
추가하고 콘솔창에서 확인 부탁드려요!

현재 댓글이 빈배열 이미지 Url을 필요로 해서 임시로 넣어두었어요. 여기 PR에서 댓글 작성 잘 동작할거에요!

<!--
## 🕶️ Requirements Checklist
- [ ]

(기능 명세서상 내용을 복사해서 테스트해주세요)
-->


## 📸 Screenshot

https://github.com/user-attachments/assets/f9bfcba8-716d-45d1-9111-6d61e522c7f1






