### PR TITLE
Feat(ui): Swiper -> Carousel (내부구현) 컴포넌트 변경 및 패키지 제거

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -25,7 +25,6 @@
     "react-router": "^7.6.3",
     "react-router-dom": "^7.6.3",
     "react-textarea-autosize": "^8.5.9",
-    "swiper": "^11.2.10",
     "zod": "^4.0.17"
   },
   "devDependencies": {

--- a/apps/client/src/pages/home/home-page.tsx
+++ b/apps/client/src/pages/home/home-page.tsx
@@ -13,8 +13,6 @@ import { routePath } from '@shared/router/path.ts';
 
 import * as styles from './home-page.css.ts';
 
-import 'swiper/swiper-bundle.css';
-
 const HomePage = () => {
   const navigate = useNavigate();
 

--- a/apps/client/src/widgets/home/components/features-section/features-section.tsx
+++ b/apps/client/src/widgets/home/components/features-section/features-section.tsx
@@ -39,7 +39,8 @@ export const FeaturesSection = ({ height = 'md' }: featureSectionProps) => {
         <Carousel
           slidesPerView={'auto'}
           modules={['Pagination']}
-          onSlideChange={(swiper) => setCurrentPage(swiper)}
+          infinite={false}
+          onSlideChange={(index: number) => setCurrentPage(index)}
           onSlideEnd={() => setCurrentPage(2)}
           className={styles.tipList}
         >

--- a/apps/client/src/widgets/home/components/features-section/features-section.tsx
+++ b/apps/client/src/widgets/home/components/features-section/features-section.tsx
@@ -1,9 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Pagination } from 'swiper/modules';
-import { Swiper, SwiperSlide } from 'swiper/react';
 
-import { Indicator } from '@bds/ui';
+import { Carousel, Indicator } from '@bds/ui';
 import { Icon } from '@bds/ui/icons';
 
 import CommunityLink from '@widgets/home/components/community-link/community-link.tsx';
@@ -38,42 +36,34 @@ export const FeaturesSection = ({ height = 'md' }: featureSectionProps) => {
           <Icon name="bulb" color="gray800" />
           <p className={styles.title}>보험 Tip</p>
         </div>
-        <Swiper
-          slidesPerView="auto"
-          spaceBetween={10}
-          loop={false}
-          autoplay={{
-            delay: 0,
-            disableOnInteraction: false,
-            pauseOnMouseEnter: true,
-          }}
-          speed={500}
-          modules={[Pagination]}
-          centeredSlides={false}
-          onSlideChange={(swiper) => setCurrentPage(swiper.realIndex)}
-          onReachEnd={() => setCurrentPage(2)}
+        <Carousel
+          slidesPerView={'auto'}
+          modules={['Pagination']}
+          onSlideChange={(swiper) => setCurrentPage(swiper)}
+          onSlideEnd={() => setCurrentPage(2)}
           className={styles.tipList}
         >
-          <SwiperSlide className={styles.slideItem}>
+          <Carousel.Item className={styles.slideItem}>
             <Tip
               title="보험 상령일이란?"
               contents="생일에 6개월을 더한 날로, 보험료 인상 기준이 돼요."
             />
-          </SwiperSlide>
-          <SwiperSlide className={styles.slideItem}>
+          </Carousel.Item>
+          <Carousel.Item className={styles.slideItem}>
             <Tip
               title="진단비와 수술비의 차이"
               contents="진단비는 병명 확정 시, 수술비는 실제 수술 시 지급돼요."
               bgColor={'gray'}
             />
-          </SwiperSlide>
-          <SwiperSlide className={styles.slideItem}>
+          </Carousel.Item>
+          <Carousel.Item className={styles.slideItem}>
             <Tip
               title="비갱신형 보험이 뭐예요?"
               contents="약관이 바뀌지 않고 보험료도 만기까지 그대로 유지돼요."
             />
-          </SwiperSlide>
-        </Swiper>
+          </Carousel.Item>
+        </Carousel>
+
         <div className={styles.indicatorContainer}>
           <Indicator current={currentPage} total={3} />
         </div>

--- a/apps/client/src/widgets/home/components/info-section/info-section.css.ts
+++ b/apps/client/src/widgets/home/components/info-section/info-section.css.ts
@@ -1,4 +1,4 @@
-import { globalStyle, style } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
 
 import { themeVars } from '@bds/ui/styles';
 
@@ -31,15 +31,7 @@ export const title = style({
 });
 
 export const homeCardList = style({
-  display: 'flex',
-  flexDirection: 'row',
-  gap: '0.8rem',
-  overflowX: 'auto',
-});
-
-globalStyle(`${homeCardList} .swiper-wrapper`, {
-  transitionTimingFunction: 'linear',
-  padding: '1.8rem 0 2.2rem 0',
+  padding: '1rem 0 1.6rem 0',
 });
 
 export const homeCardIcon = style({

--- a/apps/client/src/widgets/home/components/info-section/info-section.tsx
+++ b/apps/client/src/widgets/home/components/info-section/info-section.tsx
@@ -1,8 +1,7 @@
 import { useNavigate } from 'react-router-dom';
-import { Autoplay } from 'swiper/modules';
-import { Swiper, SwiperSlide } from 'swiper/react';
+import { SwiperSlide } from 'swiper/react';
 
-import { Button } from '@bds/ui';
+import { Button, Carousel } from '@bds/ui';
 
 import HomeCard from '@widgets/home/components/home-card/home-card.tsx';
 import { homeCardConfig } from '@widgets/home/configs/home-card-config.ts';
@@ -34,38 +33,22 @@ export const InfoSection = () => {
           딱 맞는 보험, 어렵지 않게 찾을 수 있어요!
         </p>
       </div>
-      <div className={styles.homeCardList}>
-        <Swiper
-          spaceBetween={8}
-          slidesPerView="auto"
-          loop={true}
-          autoplay={{
-            delay: 0,
-            disableOnInteraction: false,
-            pauseOnMouseEnter: true,
-          }}
-          speed={1500}
-          modules={[Autoplay]}
-          allowTouchMove={true}
-          centeredSlides={true}
-          className={styles.homeCardList}
-        >
-          {homeCardConfig.map((card, index) => (
-            <SwiperSlide key={index} style={{ width: 'auto' }}>
-              <HomeCard
-                icon={
-                  <img
-                    src={card.icon}
-                    alt={card.target}
-                    className={styles.homeCardIcon}
-                  />
-                }
-                title={card.target}
-              />
-            </SwiperSlide>
-          ))}
-        </Swiper>
-      </div>
+      <Carousel slidesPerView={4.5} autoPlay className={styles.homeCardList}>
+        {homeCardConfig.map((card, index) => (
+          <SwiperSlide key={index} style={{ width: 'auto' }}>
+            <HomeCard
+              icon={
+                <img
+                  src={card.icon}
+                  alt={card.target}
+                  className={styles.homeCardIcon}
+                />
+              }
+              title={card.target}
+            />
+          </SwiperSlide>
+        ))}
+      </Carousel>
       <div className={styles.bottomButton}>
         <Button variant={'white_fill'} size={'lg'} onClick={handleNavigate}>
           맞춤 보험 추천 받으러 가기

--- a/apps/client/src/widgets/home/components/info-section/info-section.tsx
+++ b/apps/client/src/widgets/home/components/info-section/info-section.tsx
@@ -1,5 +1,4 @@
 import { useNavigate } from 'react-router-dom';
-import { SwiperSlide } from 'swiper/react';
 
 import { Button, Carousel } from '@bds/ui';
 
@@ -35,7 +34,7 @@ export const InfoSection = () => {
       </div>
       <Carousel slidesPerView={4.5} autoPlay className={styles.homeCardList}>
         {homeCardConfig.map((card, index) => (
-          <SwiperSlide key={index} style={{ width: 'auto' }}>
+          <Carousel.Item key={index} style={{ width: 'auto' }}>
             <HomeCard
               icon={
                 <img
@@ -46,7 +45,7 @@ export const InfoSection = () => {
               }
               title={card.target}
             />
-          </SwiperSlide>
+          </Carousel.Item>
         ))}
       </Carousel>
       <div className={styles.bottomButton}>

--- a/apps/client/src/widgets/home/components/info-section/recommended-info-section.css.ts
+++ b/apps/client/src/widgets/home/components/info-section/recommended-info-section.css.ts
@@ -1,4 +1,4 @@
-import { globalStyle, style } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
 
 import { themeVars } from '@bds/ui/styles';
 
@@ -31,11 +31,6 @@ export const chipList = style({
 });
 
 export const homeCardList = style({
-  overflowX: 'auto',
-});
-
-globalStyle(`${homeCardList}  .swiper-wrapper`, {
-  transitionTimingFunction: 'linear',
   paddingBottom: '2.2rem',
 });
 

--- a/apps/client/src/widgets/home/components/info-section/recommended-info-section.tsx
+++ b/apps/client/src/widgets/home/components/info-section/recommended-info-section.tsx
@@ -1,11 +1,8 @@
-import { useMemo } from 'react';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { IconName } from 'node_modules/@bds/ui/src/icons/icon-list.ts';
 import { useNavigate } from 'react-router-dom';
-import { Autoplay } from 'swiper/modules';
-import { Swiper, SwiperSlide } from 'swiper/react';
+import { SwiperSlide } from 'swiper/react';
 
-import { Chip, TextButton } from '@bds/ui';
+import { Carousel, Chip, TextButton } from '@bds/ui';
 import { Icon } from '@bds/ui/icons';
 
 import HomeCard from '@widgets/home/components/home-card/home-card.tsx';
@@ -38,21 +35,6 @@ export const RecommendedInfoSection = ({
   const targetToIconMap = new Map(
     homeCardConfig.map(({ target, icon }) => [target, icon]),
   );
-
-  const cardList = useMemo(() => {
-    if (!reportSummary?.statuses) {
-      return [];
-    }
-
-    return [...reportSummary.statuses, ...reportSummary.statuses].map(
-      (card, index) => ({
-        key: index,
-        title: card.target || '',
-        status: card.status as StatusType,
-        icon: targetToIconMap.get(card.target || '') as IconName,
-      }),
-    );
-  }, [reportSummary?.statuses, targetToIconMap]);
 
   if (!reportSummary) {
     return;
@@ -94,36 +76,7 @@ export const RecommendedInfoSection = ({
         </div>
       </div>
 
-      <Swiper
-        spaceBetween={8}
-        slidesPerView="auto"
-        loop={true}
-        autoplay={{
-          delay: 0,
-          disableOnInteraction: false,
-          pauseOnMouseEnter: true,
-        }}
-        speed={1500}
-        modules={[Autoplay]}
-        allowTouchMove={true}
-        centeredSlides={true}
-        className={styles.homeCardList}
-      >
-        {cardList.map((card, index) => (
-          <SwiperSlide key={index} style={{ width: 'auto' }}>
-            <HomeCard
-              icon={
-                <img
-                  src={card.icon}
-                  alt={card.title}
-                  className={styles.homeCardIcon}
-                />
-              }
-              title={card.title}
-              status={card.status as StatusType}
-            />
-          </SwiperSlide>
-        ))}
+      <Carousel slidesPerView={4.5} autoPlay className={styles.homeCardList}>
         {reportSummary.statuses?.map((card, index) => (
           <SwiperSlide key={index} style={{ width: 'auto' }}>
             <HomeCard
@@ -139,7 +92,7 @@ export const RecommendedInfoSection = ({
             />
           </SwiperSlide>
         ))}
-      </Swiper>
+      </Carousel>
 
       <div className={styles.bottomButton}>
         <TextButton color={'white'} size="sm" onClick={handleNavigateReport}>

--- a/apps/client/src/widgets/home/components/info-section/recommended-info-section.tsx
+++ b/apps/client/src/widgets/home/components/info-section/recommended-info-section.tsx
@@ -1,6 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
-import { SwiperSlide } from 'swiper/react';
 
 import { Carousel, Chip, TextButton } from '@bds/ui';
 import { Icon } from '@bds/ui/icons';
@@ -78,7 +77,7 @@ export const RecommendedInfoSection = ({
 
       <Carousel slidesPerView={4.5} autoPlay className={styles.homeCardList}>
         {reportSummary.statuses?.map((card, index) => (
-          <SwiperSlide key={index} style={{ width: 'auto' }}>
+          <Carousel.Item key={index} style={{ width: 'auto' }}>
             <HomeCard
               icon={
                 <img
@@ -90,7 +89,7 @@ export const RecommendedInfoSection = ({
               title={card.target || ''}
               status={card.status as StatusType}
             />
-          </SwiperSlide>
+          </Carousel.Item>
         ))}
       </Carousel>
 

--- a/apps/client/src/widgets/login/components/login-slide/login-slide.css.ts
+++ b/apps/client/src/widgets/login/components/login-slide/login-slide.css.ts
@@ -20,19 +20,19 @@ globalStyle('.swiper-slide', {
 });
 
 export const body = style({
-  display: 'flex',
-  flexDirection: 'column',
-  height: '100svh',
+  // display: 'flex',
+  // flexDirection: 'column',
+  // height: '100svh',
 });
 
 export const slideImageSection = style({
-  height: 'calc(100% - 17rem)',
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'center',
   alignItems: 'center',
   width: '100%',
   marginTop: '6svh',
+  height: 'fit-content',
 });
 
 export const contentTextContainer = style({
@@ -66,6 +66,18 @@ export const bottomContainer = style({
   justifyContent: 'center',
   gap: '3.2rem',
   alignSelf: 'stretch',
+});
+
+export const bodyContainer = style({
+  height: 'calc(100vh - 13.9rem)',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+});
+export const CarouselContainer = style({
+  height: 'fit-content',
+  display: 'flex',
+  alignItems: 'center',
 });
 
 export const indicatorContainer = style({

--- a/apps/client/src/widgets/login/components/login-slide/login-slide.css.ts
+++ b/apps/client/src/widgets/login/components/login-slide/login-slide.css.ts
@@ -1,11 +1,5 @@
 import { style } from '@vanilla-extract/css';
 
-export const body = style({
-  // display: 'flex',
-  // flexDirection: 'column',
-  // height: '100svh',
-});
-
 export const slideImageSection = style({
   display: 'flex',
   flexDirection: 'column',

--- a/apps/client/src/widgets/login/components/login-slide/login-slide.css.ts
+++ b/apps/client/src/widgets/login/components/login-slide/login-slide.css.ts
@@ -1,23 +1,4 @@
-import { globalStyle, style } from '@vanilla-extract/css';
-
-globalStyle('.swiper', {
-  width: '100%',
-  height: '100%',
-  overflow: 'hidden',
-});
-
-globalStyle('.swiper-wrapper', {
-  display: 'flex',
-  flexDirection: 'row',
-  width: '100%',
-  height: '100%',
-});
-
-globalStyle('.swiper-slide', {
-  width: '100%',
-  height: '100%',
-  flexShrink: 0,
-});
+import { style } from '@vanilla-extract/css';
 
 export const body = style({
   // display: 'flex',

--- a/apps/client/src/widgets/login/components/login-slide/login-slide.tsx
+++ b/apps/client/src/widgets/login/components/login-slide/login-slide.tsx
@@ -18,7 +18,7 @@ const LoginSlide = () => {
   };
 
   return (
-    <div className={styles.body}>
+    <>
       <section className={styles.bodyContainer}>
         <Carousel
           infinite={false}
@@ -59,7 +59,7 @@ const LoginSlide = () => {
         </div>
         <KakaoLoginButton />
       </section>
-    </div>
+    </>
   );
 };
 

--- a/apps/client/src/widgets/login/components/login-slide/login-slide.tsx
+++ b/apps/client/src/widgets/login/components/login-slide/login-slide.tsx
@@ -1,9 +1,6 @@
 import { useState } from 'react';
-import type { Swiper as SwiperClass } from 'swiper';
-import { Autoplay, Pagination } from 'swiper/modules';
-import { Swiper, SwiperSlide } from 'swiper/react';
 
-import { Chip, Indicator } from '@bds/ui';
+import { Carousel, Chip, Indicator } from '@bds/ui';
 
 import { LOGIN_TEXT } from '@widgets/login/constants/login-content';
 
@@ -16,43 +13,46 @@ import * as styles from './login-slide.css';
 const LoginSlide = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
 
-  const handleSlideChange = (swiper: SwiperClass) => {
-    setCurrentIndex(swiper.realIndex);
+  const handleSlideChange = (number: number) => {
+    setCurrentIndex(number);
   };
 
   return (
     <div className={styles.body}>
-      <Swiper
-        modules={[Autoplay, Pagination]}
-        autoplay={{ delay: 5000, stopOnLastSlide: true }}
-        speed={500}
-        onSlideChange={handleSlideChange}
-      >
-        {LOGIN_TEXT.TITLE.map((_, idx) => (
-          <SwiperSlide key={idx}>
-            <section className={styles.slideImageSection}>
-              <img
-                src={LOGIN_TEXT.IMAGE_URL[idx]}
-                width={'62%'}
-                alt={LOGIN_TEXT.ALT_TAG[idx]}
-              />
-              <div className={styles.contentTextContainer}>
-                <div className={styles.contentHeader}>
-                  <Chip
-                    label={LOGIN_TEXT.CHIP[idx]}
-                    variant="square"
-                    size="small"
-                    fontColor="primary600"
-                    backgroundColor="primary100"
-                  />
-                  <Title title={LOGIN_TEXT.TITLE[idx]} />
+      <section className={styles.bodyContainer}>
+        <Carousel
+          infinite={false}
+          modules={['Navigation']}
+          slidesPerView={1}
+          className={styles.CarouselContainer}
+          onSlideChange={handleSlideChange}
+        >
+          {LOGIN_TEXT.TITLE.map((_, idx) => (
+            <Carousel.Item key={idx}>
+              <section className={styles.slideImageSection}>
+                <img
+                  src={LOGIN_TEXT.IMAGE_URL[idx]}
+                  width={'62%'}
+                  alt={LOGIN_TEXT.ALT_TAG[idx]}
+                />
+                <div className={styles.contentTextContainer}>
+                  <div className={styles.contentHeader}>
+                    <Chip
+                      label={LOGIN_TEXT.CHIP[idx]}
+                      variant="square"
+                      size="small"
+                      fontColor="primary600"
+                      backgroundColor="primary100"
+                    />
+                    <Title title={LOGIN_TEXT.TITLE[idx]} />
+                  </div>
+                  <SubTitle subtitle={LOGIN_TEXT.DESCRIPTION[idx]} />
                 </div>
-                <SubTitle subtitle={LOGIN_TEXT.DESCRIPTION[idx]} />
-              </div>
-            </section>
-          </SwiperSlide>
-        ))}
-      </Swiper>
+              </section>
+            </Carousel.Item>
+          ))}
+        </Carousel>
+      </section>
       <section className={styles.bottomContainer}>
         <div className={styles.indicatorContainer}>
           <Indicator current={currentIndex} total={2} />

--- a/packages/bds-ui/src/components/carousel/carousel.tsx
+++ b/packages/bds-ui/src/components/carousel/carousel.tsx
@@ -391,8 +391,8 @@ const Carousel = ({
         {/* Navigation */}
         {modules.includes('Navigation') && (
           <>
-            <CarouselArrow direction="left" />
-            <CarouselArrow direction="right" />
+            {contextValue.canGoNext && <CarouselArrow direction="right" />}
+            {contextValue.canGoPrev && <CarouselArrow direction="left" />}
           </>
         )}
       </div>

--- a/packages/bds-ui/src/components/carousel/hooks/use-carousel-virtual.ts
+++ b/packages/bds-ui/src/components/carousel/hooks/use-carousel-virtual.ts
@@ -57,7 +57,9 @@ export function useCarouselVirtual<T>({
           dataIndex: index,
           data: item,
           style: {
+            width: `${slideWidthPercent}%`,
             height: '100%',
+            flexShrink: 0,
           },
         };
       });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,9 +129,6 @@ importers:
       react-textarea-autosize:
         specifier: ^8.5.9
         version: 8.5.9(@types/react@19.1.8)(react@19.1.0)
-      swiper:
-        specifier: ^11.2.10
-        version: 11.2.10
       zod:
         specifier: ^4.0.17
         version: 4.0.17
@@ -752,15 +749,6 @@ packages:
         integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==,
       }
 
-  '@esbuild/aix-ppc64@0.25.5':
-    resolution:
-      {
-        integrity: sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==,
-      }
-    engines: { node: '>=18' }
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.25.8':
     resolution:
       {
@@ -770,15 +758,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.25.5':
-    resolution:
-      {
-        integrity: sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==,
-      }
-    engines: { node: '>=18' }
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.25.8':
     resolution:
       {
@@ -786,15 +765,6 @@ packages:
       }
     engines: { node: '>=18' }
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.25.5':
-    resolution:
-      {
-        integrity: sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==,
-      }
-    engines: { node: '>=18' }
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.8':
@@ -806,15 +776,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.25.5':
-    resolution:
-      {
-        integrity: sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==,
-      }
-    engines: { node: '>=18' }
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.25.8':
     resolution:
       {
@@ -824,15 +785,6 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.25.5':
-    resolution:
-      {
-        integrity: sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==,
-      }
-    engines: { node: '>=18' }
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.25.8':
     resolution:
       {
@@ -840,15 +792,6 @@ packages:
       }
     engines: { node: '>=18' }
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.25.5':
-    resolution:
-      {
-        integrity: sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==,
-      }
-    engines: { node: '>=18' }
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.8':
@@ -860,15 +803,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.25.5':
-    resolution:
-      {
-        integrity: sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==,
-      }
-    engines: { node: '>=18' }
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.25.8':
     resolution:
       {
@@ -876,15 +810,6 @@ packages:
       }
     engines: { node: '>=18' }
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.25.5':
-    resolution:
-      {
-        integrity: sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==,
-      }
-    engines: { node: '>=18' }
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.8':
@@ -896,15 +821,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.25.5':
-    resolution:
-      {
-        integrity: sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==,
-      }
-    engines: { node: '>=18' }
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.25.8':
     resolution:
       {
@@ -912,15 +828,6 @@ packages:
       }
     engines: { node: '>=18' }
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.25.5':
-    resolution:
-      {
-        integrity: sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==,
-      }
-    engines: { node: '>=18' }
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.8':
@@ -932,15 +839,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.5':
-    resolution:
-      {
-        integrity: sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==,
-      }
-    engines: { node: '>=18' }
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.25.8':
     resolution:
       {
@@ -948,15 +846,6 @@ packages:
       }
     engines: { node: '>=18' }
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.25.5':
-    resolution:
-      {
-        integrity: sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==,
-      }
-    engines: { node: '>=18' }
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.8':
@@ -968,15 +857,6 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.5':
-    resolution:
-      {
-        integrity: sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==,
-      }
-    engines: { node: '>=18' }
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.25.8':
     resolution:
       {
@@ -984,15 +864,6 @@ packages:
       }
     engines: { node: '>=18' }
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.25.5':
-    resolution:
-      {
-        integrity: sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==,
-      }
-    engines: { node: '>=18' }
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.8':
@@ -1004,15 +875,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.5':
-    resolution:
-      {
-        integrity: sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==,
-      }
-    engines: { node: '>=18' }
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.25.8':
     resolution:
       {
@@ -1020,15 +882,6 @@ packages:
       }
     engines: { node: '>=18' }
     cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.25.5':
-    resolution:
-      {
-        integrity: sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==,
-      }
-    engines: { node: '>=18' }
-    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.25.8':
@@ -1040,15 +893,6 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.5':
-    resolution:
-      {
-        integrity: sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==,
-      }
-    engines: { node: '>=18' }
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.25.8':
     resolution:
       {
@@ -1058,15 +902,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.5':
-    resolution:
-      {
-        integrity: sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==,
-      }
-    engines: { node: '>=18' }
-    cpu: [arm64]
-    os: [netbsd]
-
   '@esbuild/netbsd-arm64@0.25.8':
     resolution:
       {
@@ -1074,15 +909,6 @@ packages:
       }
     engines: { node: '>=18' }
     cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.25.5':
-    resolution:
-      {
-        integrity: sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==,
-      }
-    engines: { node: '>=18' }
-    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.25.8':
@@ -1094,15 +920,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.5':
-    resolution:
-      {
-        integrity: sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==,
-      }
-    engines: { node: '>=18' }
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.25.8':
     resolution:
       {
@@ -1110,15 +927,6 @@ packages:
       }
     engines: { node: '>=18' }
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.25.5':
-    resolution:
-      {
-        integrity: sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==,
-      }
-    engines: { node: '>=18' }
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.8':
@@ -1139,15 +947,6 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.25.5':
-    resolution:
-      {
-        integrity: sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==,
-      }
-    engines: { node: '>=18' }
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.25.8':
     resolution:
       {
@@ -1156,15 +955,6 @@ packages:
     engines: { node: '>=18' }
     cpu: [x64]
     os: [sunos]
-
-  '@esbuild/win32-arm64@0.25.5':
-    resolution:
-      {
-        integrity: sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==,
-      }
-    engines: { node: '>=18' }
-    cpu: [arm64]
-    os: [win32]
 
   '@esbuild/win32-arm64@0.25.8':
     resolution:
@@ -1175,15 +965,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.5':
-    resolution:
-      {
-        integrity: sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==,
-      }
-    engines: { node: '>=18' }
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.25.8':
     resolution:
       {
@@ -1191,15 +972,6 @@ packages:
       }
     engines: { node: '>=18' }
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.25.5':
-    resolution:
-      {
-        integrity: sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==,
-      }
-    engines: { node: '>=18' }
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.8':
@@ -3493,14 +3265,6 @@ packages:
       }
     peerDependencies:
       esbuild: '>=0.12 <1'
-
-  esbuild@0.25.5:
-    resolution:
-      {
-        integrity: sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==,
-      }
-    engines: { node: '>=18' }
-    hasBin: true
 
   esbuild@0.25.8:
     resolution:
@@ -6410,13 +6174,6 @@ packages:
         integrity: sha512-BAmWG6/bx8syfc6qXPprof3Mn5vQgf5dwdUNJhsNqU9WdPt5P+ES/wQ5bxfijy8zwZgZZHslC3iAsxsuQMCzJQ==,
       }
 
-  swiper@11.2.10:
-    resolution:
-      {
-        integrity: sha512-RMeVUUjTQH+6N3ckimK93oxz6Sn5la4aDlgPzB+rBrG/smPdCTicXyhxa+woIpopz+jewEloiEE3lKo1h9w2YQ==,
-      }
-    engines: { node: '>= 4.7.0' }
-
   synckit@0.11.8:
     resolution:
       {
@@ -7591,127 +7348,64 @@ snapshots:
 
   '@emotion/hash@0.9.2': {}
 
-  '@esbuild/aix-ppc64@0.25.5':
-    optional: true
-
   '@esbuild/aix-ppc64@0.25.8':
-    optional: true
-
-  '@esbuild/android-arm64@0.25.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.8':
     optional: true
 
-  '@esbuild/android-arm@0.25.5':
-    optional: true
-
   '@esbuild/android-arm@0.25.8':
-    optional: true
-
-  '@esbuild/android-x64@0.25.5':
     optional: true
 
   '@esbuild/android-x64@0.25.8':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.5':
-    optional: true
-
   '@esbuild/darwin-arm64@0.25.8':
-    optional: true
-
-  '@esbuild/darwin-x64@0.25.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.8':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.5':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.25.8':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.25.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.8':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.5':
-    optional: true
-
   '@esbuild/linux-arm64@0.25.8':
-    optional: true
-
-  '@esbuild/linux-arm@0.25.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.8':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.5':
-    optional: true
-
   '@esbuild/linux-ia32@0.25.8':
-    optional: true
-
-  '@esbuild/linux-loong64@0.25.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.8':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.5':
-    optional: true
-
   '@esbuild/linux-mips64el@0.25.8':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.25.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.8':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.5':
-    optional: true
-
   '@esbuild/linux-riscv64@0.25.8':
-    optional: true
-
-  '@esbuild/linux-s390x@0.25.5':
     optional: true
 
   '@esbuild/linux-s390x@0.25.8':
     optional: true
 
-  '@esbuild/linux-x64@0.25.5':
-    optional: true
-
   '@esbuild/linux-x64@0.25.8':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.25.5':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.8':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.5':
-    optional: true
-
   '@esbuild/netbsd-x64@0.25.8':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.5':
-    optional: true
-
   '@esbuild/openbsd-arm64@0.25.8':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.25.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.8':
@@ -7720,25 +7414,13 @@ snapshots:
   '@esbuild/openharmony-arm64@0.25.8':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.5':
-    optional: true
-
   '@esbuild/sunos-x64@0.25.8':
-    optional: true
-
-  '@esbuild/win32-arm64@0.25.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.8':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.5':
-    optional: true
-
   '@esbuild/win32-ia32@0.25.8':
-    optional: true
-
-  '@esbuild/win32-x64@0.25.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.8':
@@ -9337,34 +9019,6 @@ snapshots:
       esbuild: 0.25.8
     transitivePeerDependencies:
       - supports-color
-
-  esbuild@0.25.5:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.5
-      '@esbuild/android-arm': 0.25.5
-      '@esbuild/android-arm64': 0.25.5
-      '@esbuild/android-x64': 0.25.5
-      '@esbuild/darwin-arm64': 0.25.5
-      '@esbuild/darwin-x64': 0.25.5
-      '@esbuild/freebsd-arm64': 0.25.5
-      '@esbuild/freebsd-x64': 0.25.5
-      '@esbuild/linux-arm': 0.25.5
-      '@esbuild/linux-arm64': 0.25.5
-      '@esbuild/linux-ia32': 0.25.5
-      '@esbuild/linux-loong64': 0.25.5
-      '@esbuild/linux-mips64el': 0.25.5
-      '@esbuild/linux-ppc64': 0.25.5
-      '@esbuild/linux-riscv64': 0.25.5
-      '@esbuild/linux-s390x': 0.25.5
-      '@esbuild/linux-x64': 0.25.5
-      '@esbuild/netbsd-arm64': 0.25.5
-      '@esbuild/netbsd-x64': 0.25.5
-      '@esbuild/openbsd-arm64': 0.25.5
-      '@esbuild/openbsd-x64': 0.25.5
-      '@esbuild/sunos-x64': 0.25.5
-      '@esbuild/win32-arm64': 0.25.5
-      '@esbuild/win32-ia32': 0.25.5
-      '@esbuild/win32-x64': 0.25.5
 
   esbuild@0.25.8:
     optionalDependencies:
@@ -11185,8 +10839,6 @@ snapshots:
       lower-case: 1.1.4
       upper-case: 1.1.3
 
-  swiper@11.2.10: {}
-
   synckit@0.11.8:
     dependencies:
       '@pkgr/core': 0.2.7
@@ -11277,7 +10929,7 @@ snapshots:
 
   tsx@4.20.3:
     dependencies:
-      esbuild: 0.25.5
+      esbuild: 0.25.8
       get-tsconfig: 4.10.1
     optionalDependencies:
       fsevents: 2.3.3


### PR DESCRIPTION
## 📌 Summary

> close #443

#### 보험 추천 받은 유저 
home 페이지 - 상단 스와이퍼 (강충부)
home 페이지 - 하단 홈카드 스와이퍼

#### 보험 추천 받지 않은 유저
home 페이지 - 상단 스와이퍼 (강충부)
home 페이지 - 하단 홈카드 스와이퍼

#### 로그인 페이지 
온보딩 스와이퍼 

총 5개의 스와이퍼를 bds-ui Carousel 컴포넌트로 리펙토링 했습니다. 
++ Swiper 라이브러리를 제거했어요. 의존성을 완전히 떼어냈습니다.
 

## 로그인 페이지 

### [ 문제 발생 ]

로그인 페이지 온보딩 스와이퍼를 변경하다가, 다음과 같은 에러를 발견했습니다.

https://github.com/user-attachments/assets/df7570d1-d29a-4139-8812-92aaba6124c1

요렇게 slidePerView=1 (한 페이지에 1개의 슬라이드를 보여주겠다) 
라고 설정을 했을 때 infinite = false (무한슬라이드가 아닌 유한 슬라이드) 로 설정을 걸면
이렇게 한 뷰에 여러개의 슬라이드가 보이게 되는 것입니다. 
slidePerView=1 세팅을 했기 때문에 1개만 보여야 맞습니다. 

###  [ 원인 ]

infinite = false 에는 가상화 로직을 적용시키지 않습니다. 
가상화를 하려고 했던 이유는 무한 슬라이드이기 때문이었는데요. 그렇기 때문에 유한 슬라이드는 가상화를 적용시키지 않습니다. 
근데 infinite = false 일 때 반환하는 item 의 width 값이 세팅되어 있지 않았어요. 'auto' 때문에 그랬던 것 같아요.


###  [ 해결 ]

<img width="938" height="211" alt="스크린샷 2025-10-06 21 53 11" src="https://github.com/user-attachments/assets/1c62a9bf-1264-44fb-a703-07871b5384cf" />

그래서 이렇게 한 요소에 해당하는 width 값을 세팅해주었습니다. 
잘 작동 되는 것을 확인했어요! 

###  추가 슬라이드 변경사항 

그리고 추가로 화살표가 다음 으로 갈 페이지가 있을 때만 렌더링 되도록 스와이퍼를 개선 했습니다. 

<img width="1188" height="215" alt="스크린샷 2025-10-06 21 53 29" src="https://github.com/user-attachments/assets/873c5fd2-4584-4fb2-bf58-fd529e427235" />

이렇게 잘 작동해요

https://github.com/user-attachments/assets/c9bdf642-4a45-4654-bb81-38e95a770a46


## home 페이지

### 보험 추천 받은 유저

https://github.com/user-attachments/assets/35ead044-4c3e-4a6f-b4e4-db1cb3ffef6d


#### 보험 추천 받지 않은 유저 


https://github.com/user-attachments/assets/b2bb8a84-dbed-4608-b52c-78fb47911eaa


## To reviewer.

이 부분 가장 마지막 슬라이드부분은 좀 더 디벨롭 해볼게요. 

<img width="553" height="234" alt="스크린샷 2025-10-06 23 11 20" src="https://github.com/user-attachments/assets/f4809d1d-fb84-40ed-af7e-ce5023318f22" />
