### PR TITLE
fix(client): indicator 복제 이슈 해결

### DIFF
--- a/apps/client/src/widgets/home/components/features-section/features-section.css.ts
+++ b/apps/client/src/widgets/home/components/features-section/features-section.css.ts
@@ -20,7 +20,7 @@ export const featureSection = recipe({
         minHeight: 'calc(100vh - 474px)',
       },
       lg: {
-        minHeight: 'calc(100vh - 422px)',
+        minHeight: 'calc(100vh - 413px)',
       },
     },
   },

--- a/apps/client/src/widgets/home/components/features-section/features-section.tsx
+++ b/apps/client/src/widgets/home/components/features-section/features-section.tsx
@@ -38,7 +38,6 @@ export const FeaturesSection = ({ height = 'md' }: featureSectionProps) => {
         </div>
         <Carousel
           slidesPerView={'auto'}
-          modules={['Pagination']}
           infinite={false}
           onSlideChange={(index: number) => setCurrentPage(index)}
           onSlideEnd={() => setCurrentPage(2)}
@@ -64,7 +63,6 @@ export const FeaturesSection = ({ height = 'md' }: featureSectionProps) => {
             />
           </Carousel.Item>
         </Carousel>
-
         <div className={styles.indicatorContainer}>
           <Indicator current={currentPage} total={3} />
         </div>


### PR DESCRIPTION
## 📌 Summary

> close #456

- indicator 가 2개 보이는 이슈를 해결
- 홈의 요소 크기 재계산


## 📚 Tasks

- _해당 PR에 수행한 작업을 작성해주세요._

indicator 가 2개 보이는 이슈를 해결했어요. 

[ AS - IS ]
<img width="1412" height="464" alt="image" src="https://github.com/user-attachments/assets/8fa8fb9a-0332-434f-8853-91149fab449a" />


[ TO -BE ]

<img width="461" height="501" alt="스크린샷 2025-10-09 00 41 00" src="https://github.com/user-attachments/assets/7bf3184d-6aa6-4156-aa53-bbdb5a9a8e9d" />


작업하다가 추가로 발견한 이 밑에 부분도 함께 해결했어요. 
저희가 계산하고 있는 px 값을 변경했습니다. 화면이 슬라이드 되지 않게요.
반응형도 모두 고려해서 요소밑에 칸이 생기지 않고 + 슬라이드가 되지 않게 조정했습니다. 

[ AS - IS ]

<img width="492" height="274" alt="스크린샷 2025-10-09 00 43 09" src="https://github.com/user-attachments/assets/dfb2f97c-5934-4237-859b-92e671adba98" />

[ TO -BE ]


https://github.com/user-attachments/assets/b8ec9d9d-9a07-4940-ae57-663253883836

