### PR TITLE
Fix(client): 글 수정 시 카테고리 아이콘 추가 및 방향 조정

### DIFF
--- a/apps/client/src/pages/community/community-edit/community-edit.tsx
+++ b/apps/client/src/pages/community/community-edit/community-edit.tsx
@@ -143,6 +143,8 @@ const CommunityEdit = () => {
             <Title fontStyle="eb_md">{COMMUNITY_CONTENT.TITLE.HEADER}</Title>
             <FilterDropDown
               optionTitle={category ? category.label : '카테고리 선택'}
+              rightIcon={<Icon name="caret_up_sm" />}
+              isIconRotate
             >
               {categoryOptions.map((option) => (
                 <TextButton

--- a/apps/client/src/pages/community/community-write/community-write.tsx
+++ b/apps/client/src/pages/community/community-write/community-write.tsx
@@ -151,7 +151,7 @@ const CommunityWrite = () => {
             <Title fontStyle="eb_md">제목</Title>
             <FilterDropDown
               optionTitle={category ? category.label : '카테고리 선택'}
-              rightIcon={<Icon name="caret_down_sm" />}
+              rightIcon={<Icon name="caret_up_sm" />}
               isIconRotate
             >
               {categoryOptions.map((option) => (


### PR DESCRIPTION
## 📌 Summary

> close #458

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

- [x] 카테고리 오른쪽 아이콘 추가
- [x] 카테고리 오른쪽 아이콘 방향 수정

## 📚 Tasks

- _해당 PR에 수행한 작업을 작성해주세요._

1. 카테고리 오른쪽 아이콘 추가

아이콘이 수정 시에는 없고 글 작성 시에는 있는 것을 확인했습니다. 
이에 따라 오른쪽에 이 토글 아이콘을 추가했어요.

이렇게 아이콘이 누락되어 있었습니다. 

<img width="452" height="244" alt="스크린샷 2025-10-09 03 44 40" src="https://github.com/user-attachments/assets/0ddfc6cb-508b-41be-8948-6992797de9fa" />


2. 카테고리 오른쪽 아이콘 방향 수정

원래 열리면 위를 향해야하고, 열리지 않았을 때 아래를 향해야 하는데 이게 방향이 이상하게 세팅을 해두었더라구요 .. 
그래서 그 부분을 수정했습니다. 

[AS-IS]

<img width="494" height="348" alt="스크린샷 2025-10-09 03 41 51" src="https://github.com/user-attachments/assets/ab9a26b6-58c0-4b21-8d23-07a5bc4f55db" />

[TO-BE]

<img width="526" height="409" alt="스크린샷 2025-10-09 03 41 58" src="https://github.com/user-attachments/assets/bf271872-75e7-49fd-b0ce-6a89f46386d7" />

