### PR TITLE
Feat(client): 커뮤니티 인기 게시글 api 연결, 커뮤니티 스타일 수정

### DIFF
--- a/apps/client/src/shared/api/config/end-point.ts
+++ b/apps/client/src/shared/api/config/end-point.ts
@@ -17,7 +17,7 @@ export const END_POINT = {
     ) => `posts/${postId}/comments/${commentId}/reply/${commentReplyId}`,
     POST_LIKE: (postId: string) => `posts/${postId}/likes`,
     DELETE_LIKE: (postId: string) => `posts/${postId}/likes`,
-    GET_POPULAR: (size?: number) => `posts/trend?size=${size}`,
+    GET_POPULAR: 'posts/trend',
   },
   USER: {
     GET_USER_INFO: 'users/info',

--- a/apps/client/src/shared/api/config/end-point.ts
+++ b/apps/client/src/shared/api/config/end-point.ts
@@ -17,6 +17,7 @@ export const END_POINT = {
     ) => `posts/${postId}/comments/${commentId}/reply/${commentReplyId}`,
     POST_LIKE: (postId: string) => `posts/${postId}/likes`,
     DELETE_LIKE: (postId: string) => `posts/${postId}/likes`,
+    GET_POPULAR: (size?: number) => `posts/trend?size=${size}`,
   },
   USER: {
     GET_USER_INFO: 'users/info',

--- a/apps/client/src/shared/api/domain/community/queries.ts
+++ b/apps/client/src/shared/api/domain/community/queries.ts
@@ -26,6 +26,7 @@ import {
   FeedUpdateResponse,
   LikeAddResponse,
   LikeDeleteResponse,
+  PopularFeedResponse,
 } from '@shared/api/types/types';
 
 // =============================================================================
@@ -68,6 +69,13 @@ export const COMMUNITY_QUERY_OPTIONS = {
         lastPage?.data?.nextCursor ? lastPage.data.nextCursor : undefined,
       initialPageParam: 0,
     }),
+
+  POPULAR_FEED: (size?: number) => {
+    return queryOptions({
+      queryKey: COMMUNITY_QUERY_KEY.POPULAR_FEED(),
+      queryFn: () => getPopularFeed(size),
+    });
+  },
 };
 
 // =============================================================================
@@ -150,6 +158,15 @@ export const getCommentReply = async (
       ? `${END_POINT.COMMUNITY.GET_COMMENT_REPLY(postId, commentId)}?size=10`
       : `${END_POINT.COMMUNITY.GET_COMMENT_REPLY(postId, commentId)}?cursor=${pageParam}&size=10`;
   const response = await api.get(url).json<CommentReplyResponse>();
+  return response;
+};
+
+export const getPopularFeed = async (
+  size?: number,
+): Promise<PopularFeedResponse | null> => {
+  const response = await api
+    .get(END_POINT.COMMUNITY.GET_POPULAR(size))
+    .json<PopularFeedResponse>();
   return response;
 };
 

--- a/apps/client/src/shared/api/domain/community/queries.ts
+++ b/apps/client/src/shared/api/domain/community/queries.ts
@@ -165,7 +165,7 @@ export const getPopularFeed = async (
   size?: number,
 ): Promise<PopularFeedResponse | null> => {
   const response = await api
-    .get(END_POINT.COMMUNITY.GET_POPULAR(size))
+    .get(`${END_POINT.COMMUNITY.GET_POPULAR}?size=${size}`)
     .json<PopularFeedResponse>();
   return response;
 };

--- a/apps/client/src/shared/api/keys/query-key.ts
+++ b/apps/client/src/shared/api/keys/query-key.ts
@@ -53,6 +53,7 @@ export const COMMUNITY_QUERY_KEY = {
     'reply',
     commentId,
   ],
+  POPULAR_FEED: () => [...COMMUNITY_QUERY_KEY.ALL, 'popular'],
 } as const;
 
 export const COMMUNITY_MUTATION_KEY = {

--- a/apps/client/src/shared/api/types/types.ts
+++ b/apps/client/src/shared/api/types/types.ts
@@ -236,6 +236,11 @@ export type FeedDeleteResponse =
 /**
  * @description 이미지 업로드 응답
  * */
-
 export type ImageUploadResponse =
   paths['/files/upload']['post']['responses']['200']['content']['*/*'];
+
+/**
+ * @description 실시간 인기 게시글 조회 응답
+ */
+export type PopularFeedResponse =
+  paths['/posts/trend']['get']['responses']['200']['content']['*/*'];

--- a/apps/client/src/widgets/community/components/feed-card/feed-card.css.ts
+++ b/apps/client/src/widgets/community/components/feed-card/feed-card.css.ts
@@ -43,18 +43,6 @@ export const content = style({
   textOverflow: 'ellipsis',
 });
 
-// export const contentWrapper = style({
-//   display: '-webkit-box',
-//   marginTop: '0.6rem',
-//   ...themeVars.fontStyles.body2_r_14,
-//   color: themeVars.color.gray900,
-
-//   WebkitBoxOrient: 'vertical',
-//   WebkitLineClamp: 2,
-//   overflow: 'hidden',
-//   textOverflow: 'ellipsis',
-// });
-
 export const stats = style({
   display: 'flex',
   margin: '1rem 0 0.8rem',

--- a/apps/client/src/widgets/community/components/feed-card/feed-card.css.ts
+++ b/apps/client/src/widgets/community/components/feed-card/feed-card.css.ts
@@ -5,6 +5,7 @@ import { themeVars } from '@bds/ui/styles';
 export const container = style({
   display: 'flex',
   flexDirection: 'column',
+  justifyContent: 'space-between',
   padding: '1rem 1.2rem',
 
   width: '24.7rem',
@@ -14,17 +15,45 @@ export const container = style({
   backgroundColor: themeVars.color.whiteBackground,
 });
 
-export const contentWrapper = style({
+export const titleContentContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.6rem',
+});
+
+export const title = style({
+  ...themeVars.fontStyles.head2_b_14,
+  color: themeVars.color.gray900,
+
   display: '-webkit-box',
-  marginTop: '0.6rem',
+  WebkitBoxOrient: 'vertical',
+  WebkitLineClamp: 1,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+});
+
+export const content = style({
   ...themeVars.fontStyles.body2_r_14,
   color: themeVars.color.gray900,
 
+  display: '-webkit-box',
   WebkitBoxOrient: 'vertical',
   WebkitLineClamp: 2,
   overflow: 'hidden',
   textOverflow: 'ellipsis',
 });
+
+// export const contentWrapper = style({
+//   display: '-webkit-box',
+//   marginTop: '0.6rem',
+//   ...themeVars.fontStyles.body2_r_14,
+//   color: themeVars.color.gray900,
+
+//   WebkitBoxOrient: 'vertical',
+//   WebkitLineClamp: 2,
+//   overflow: 'hidden',
+//   textOverflow: 'ellipsis',
+// });
 
 export const stats = style({
   display: 'flex',

--- a/apps/client/src/widgets/community/components/feed-card/feed-card.tsx
+++ b/apps/client/src/widgets/community/components/feed-card/feed-card.tsx
@@ -8,7 +8,7 @@ interface FeedCardProps {
   content: string;
   commentCount: number;
   likeCount: number;
-  onClick: () => void;
+  onClick?: () => void;
 }
 
 const FeedCard = ({

--- a/apps/client/src/widgets/community/components/feed-card/feed-card.tsx
+++ b/apps/client/src/widgets/community/components/feed-card/feed-card.tsx
@@ -19,17 +19,20 @@ const FeedCard = ({
 }: FeedCardProps) => {
   return (
     <div className={styles.container}>
-      <Title fontStyle="bd_sm">{title}</Title>
-
-      <div className={styles.contentWrapper}>{content}</div>
+      <div className={styles.titleContentContainer}>
+        <div className={styles.title}>
+          <Title fontStyle="bd_sm">{title}</Title>
+        </div>
+        <p className={styles.content}>{content}</p>
+      </div>
 
       <div className={styles.stats}>
         <div className={styles.heart}>
-          <Icon name="heart" width="2rem" height="2rem" />
+          <Icon name="heart" width="2rem" height="2rem" color="gray600" />
           <p className={styles.statsNumber}>{likeCount}</p>
         </div>
         <div className={styles.reply}>
-          <Icon name="chat_square" width="2rem" height="2rem" />
+          <Icon name="chat_square" width="2rem" height="2rem" color="gray600" />
           <p className={styles.statsNumber}>{commentCount}</p>
         </div>
       </div>

--- a/apps/client/src/widgets/community/components/feed-card/feed-card.tsx
+++ b/apps/client/src/widgets/community/components/feed-card/feed-card.tsx
@@ -8,6 +8,7 @@ interface FeedCardProps {
   content: string;
   commentCount: number;
   likeCount: number;
+  likedByCurrentUser: boolean;
   onClick?: () => void;
 }
 
@@ -16,6 +17,7 @@ const FeedCard = ({
   content,
   commentCount,
   likeCount,
+  likedByCurrentUser,
 }: FeedCardProps) => {
   return (
     <div className={styles.container}>
@@ -28,7 +30,12 @@ const FeedCard = ({
 
       <div className={styles.stats}>
         <div className={styles.heart}>
-          <Icon name="heart" width="2rem" height="2rem" color="gray600" />
+          <Icon
+            name={likedByCurrentUser ? 'heart_fill' : 'heart'}
+            width="2rem"
+            height="2rem"
+            color={likedByCurrentUser ? 'error' : 'gray600'}
+          />
           <p className={styles.statsNumber}>{likeCount}</p>
         </div>
         <div className={styles.reply}>

--- a/apps/client/src/widgets/community/components/feed-list/feed-list.css.ts
+++ b/apps/client/src/widgets/community/components/feed-list/feed-list.css.ts
@@ -4,7 +4,7 @@ export const listAllContainer = style({
   display: 'flex',
   flexDirection: 'column',
   gap: '1rem',
-  padding: '0 1.6rem',
+  paddingLeft: '1.6rem',
 });
 
 export const chipContainer = style({
@@ -35,6 +35,7 @@ export const listContentsContainer = style({
   flexDirection: 'column',
   paddingTop: '1.2rem',
   gap: '0.8rem',
+  paddingRight: '1.6rem',
 });
 
 export const dropDownContainer = style({

--- a/apps/client/src/widgets/community/components/live-popular-feed/live-popular-feed.tsx
+++ b/apps/client/src/widgets/community/components/live-popular-feed/live-popular-feed.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useNavigate } from 'react-router';
 
 import { Carousel, Indicator, Title } from '@bds/ui';
 import { Icon } from '@bds/ui/icons';
@@ -8,6 +7,7 @@ import { Icon } from '@bds/ui/icons';
 import FeedCard from '@widgets/community/components/feed-card/feed-card';
 
 import { COMMUNITY_QUERY_OPTIONS } from '@shared/api/domain/community/queries';
+import { useNavigateTo } from '@shared/hooks/use-navigate-to';
 import { routePath } from '@shared/router/path';
 
 import * as styles from './live-popular-feed.css';
@@ -19,11 +19,6 @@ const LivePopularFeed = () => {
   const { data: popularFeedData } = useQuery({
     ...COMMUNITY_QUERY_OPTIONS.POPULAR_FEED(TOTAL_POPULAR_FEED),
   });
-  const navigate = useNavigate();
-
-  const handleGoToDetailPage = (postId: number | undefined) => {
-    navigate(routePath.COMMUNITY_DETAIL.replace(':postId', String(postId)));
-  };
 
   return (
     <div className={styles.container}>
@@ -52,7 +47,14 @@ const LivePopularFeed = () => {
                 content={content ?? ''}
                 commentCount={commentCount ?? 0}
                 likeCount={likeCount ?? 0}
-                onClick={() => handleGoToDetailPage(postId)}
+                onClick={() =>
+                  useNavigateTo(
+                    routePath.COMMUNITY_DETAIL.replace(
+                      ':postId',
+                      String(postId),
+                    ),
+                  )
+                }
               />
             </Carousel.Item>
           ),

--- a/apps/client/src/widgets/community/components/live-popular-feed/live-popular-feed.tsx
+++ b/apps/client/src/widgets/community/components/live-popular-feed/live-popular-feed.tsx
@@ -20,7 +20,6 @@ const LivePopularFeed = () => {
   const { data: popularFeedData } = useQuery({
     ...COMMUNITY_QUERY_OPTIONS.POPULAR_FEED(TOTAL_POPULAR_FEED),
   });
-
   return (
     <div className={styles.container}>
       <div className={styles.titleContainer}>
@@ -41,7 +40,14 @@ const LivePopularFeed = () => {
         className={styles.carousel}
       >
         {popularFeedData?.data?.posts?.map(
-          ({ title, content, commentCount, likeCount, postId }) => (
+          ({
+            title,
+            content,
+            commentCount,
+            likeCount,
+            postId,
+            likedByCurrentUser,
+          }) => (
             <Carousel.Item
               key={postId}
               className={styles.carouselItem}
@@ -56,6 +62,7 @@ const LivePopularFeed = () => {
                 content={content ?? ''}
                 commentCount={commentCount ?? 0}
                 likeCount={likeCount ?? 0}
+                likedByCurrentUser={likedByCurrentUser ?? false}
               />
             </Carousel.Item>
           ),

--- a/apps/client/src/widgets/community/components/live-popular-feed/live-popular-feed.tsx
+++ b/apps/client/src/widgets/community/components/live-popular-feed/live-popular-feed.tsx
@@ -40,8 +40,8 @@ const LivePopularFeed = () => {
         className={styles.carousel}
       >
         {popularFeedData?.data?.posts?.map(
-          ({ title, content, commentCount, likeCount, postId }, index) => (
-            <Carousel.Item key={index} className={styles.carouselItem}>
+          ({ title, content, commentCount, likeCount, postId }) => (
+            <Carousel.Item key={postId} className={styles.carouselItem}>
               <FeedCard
                 title={title ?? ''}
                 content={content ?? ''}

--- a/apps/client/src/widgets/community/components/live-popular-feed/live-popular-feed.tsx
+++ b/apps/client/src/widgets/community/components/live-popular-feed/live-popular-feed.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router';
 
 import { Carousel, Indicator, Title } from '@bds/ui';
 import { Icon } from '@bds/ui/icons';
@@ -7,6 +8,7 @@ import { Icon } from '@bds/ui/icons';
 import FeedCard from '@widgets/community/components/feed-card/feed-card';
 
 import { COMMUNITY_QUERY_OPTIONS } from '@shared/api/domain/community/queries';
+import { routePath } from '@shared/router/path';
 
 import * as styles from './live-popular-feed.css';
 
@@ -17,6 +19,11 @@ const LivePopularFeed = () => {
   const { data: popularFeedData } = useQuery({
     ...COMMUNITY_QUERY_OPTIONS.POPULAR_FEED(TOTAL_POPULAR_FEED),
   });
+  const navigate = useNavigate();
+
+  const handleGoToDetailPage = (postId: number | undefined) => {
+    navigate(routePath.COMMUNITY_DETAIL.replace(':postId', String(postId)));
+  };
 
   return (
     <div className={styles.container}>
@@ -38,16 +45,14 @@ const LivePopularFeed = () => {
         className={styles.carousel}
       >
         {popularFeedData?.data?.posts?.map(
-          ({ title, content, commentCount, likeCount }, index) => (
+          ({ title, content, commentCount, likeCount, postId }, index) => (
             <Carousel.Item key={index} className={styles.carouselItem}>
               <FeedCard
                 title={title ?? ''}
                 content={content ?? ''}
                 commentCount={commentCount ?? 0}
                 likeCount={likeCount ?? 0}
-                onClick={() => {
-                  // @TODO 해당 CommunityDetail로 이동
-                }}
+                onClick={() => handleGoToDetailPage(postId)}
               />
             </Carousel.Item>
           ),

--- a/apps/client/src/widgets/community/components/live-popular-feed/live-popular-feed.tsx
+++ b/apps/client/src/widgets/community/components/live-popular-feed/live-popular-feed.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 
 import { Carousel, Indicator, Title } from '@bds/ui';
 import { Icon } from '@bds/ui/icons';
@@ -7,7 +8,6 @@ import { Icon } from '@bds/ui/icons';
 import FeedCard from '@widgets/community/components/feed-card/feed-card';
 
 import { COMMUNITY_QUERY_OPTIONS } from '@shared/api/domain/community/queries';
-import { useNavigateTo } from '@shared/hooks/use-navigate-to';
 import { routePath } from '@shared/router/path';
 
 import * as styles from './live-popular-feed.css';
@@ -15,6 +15,7 @@ import * as styles from './live-popular-feed.css';
 const TOTAL_POPULAR_FEED = 3;
 
 const LivePopularFeed = () => {
+  const navigate = useNavigate();
   const [currentPage, setCurrentPage] = useState(0);
   const { data: popularFeedData } = useQuery({
     ...COMMUNITY_QUERY_OPTIONS.POPULAR_FEED(TOTAL_POPULAR_FEED),
@@ -41,20 +42,20 @@ const LivePopularFeed = () => {
       >
         {popularFeedData?.data?.posts?.map(
           ({ title, content, commentCount, likeCount, postId }) => (
-            <Carousel.Item key={postId} className={styles.carouselItem}>
+            <Carousel.Item
+              key={postId}
+              className={styles.carouselItem}
+              onClick={() =>
+                navigate(
+                  routePath.COMMUNITY_DETAIL.replace(':postId', String(postId)),
+                )
+              }
+            >
               <FeedCard
                 title={title ?? ''}
                 content={content ?? ''}
                 commentCount={commentCount ?? 0}
                 likeCount={likeCount ?? 0}
-                onClick={() =>
-                  useNavigateTo(
-                    routePath.COMMUNITY_DETAIL.replace(
-                      ':postId',
-                      String(postId),
-                    ),
-                  )
-                }
               />
             </Carousel.Item>
           ),

--- a/apps/client/src/widgets/community/components/live-popular-feed/live-popular-feed.tsx
+++ b/apps/client/src/widgets/community/components/live-popular-feed/live-popular-feed.tsx
@@ -41,10 +41,10 @@ const LivePopularFeed = () => {
           ({ title, content, commentCount, likeCount }, index) => (
             <Carousel.Item key={index} className={styles.carouselItem}>
               <FeedCard
-                title={title || ''}
-                content={content || ''}
-                commentCount={commentCount || 0}
-                likeCount={likeCount || 0}
+                title={title ?? ''}
+                content={content ?? ''}
+                commentCount={commentCount ?? 0}
+                likeCount={likeCount ?? 0}
                 onClick={() => {
                   // @TODO 해당 CommunityDetail로 이동
                 }}
@@ -55,7 +55,7 @@ const LivePopularFeed = () => {
       </Carousel>
 
       <div className={styles.indicatorWrapper}>
-        <Indicator current={currentPage} total={3} />
+        <Indicator current={currentPage} total={TOTAL_POPULAR_FEED} />
       </div>
     </div>
   );

--- a/apps/client/src/widgets/community/components/live-popular-feed/live-popular-feed.tsx
+++ b/apps/client/src/widgets/community/components/live-popular-feed/live-popular-feed.tsx
@@ -1,16 +1,23 @@
 import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 
 import { Carousel, Indicator, Title } from '@bds/ui';
 import { Icon } from '@bds/ui/icons';
 
 import FeedCard from '@widgets/community/components/feed-card/feed-card';
-import { MOCK_FEED_CARD } from '@widgets/community/constant/mock-popular-feed';
+
+import { COMMUNITY_QUERY_OPTIONS } from '@shared/api/domain/community/queries';
 
 import * as styles from './live-popular-feed.css';
 
+const TOTAL_POPULAR_FEED = 3;
+
 const LivePopularFeed = () => {
-  // @TODO 실시간 인기 게시글 API 연동
   const [currentPage, setCurrentPage] = useState(0);
+  const { data: popularFeedData } = useQuery({
+    ...COMMUNITY_QUERY_OPTIONS.POPULAR_FEED(TOTAL_POPULAR_FEED),
+  });
+
   return (
     <div className={styles.container}>
       <div className={styles.titleContainer}>
@@ -30,14 +37,14 @@ const LivePopularFeed = () => {
         onSlideEnd={() => setCurrentPage(2)}
         className={styles.carousel}
       >
-        {MOCK_FEED_CARD.map(
-          ({ id, title, content, commentCount, likeCount }) => (
-            <Carousel.Item key={id} className={styles.carouselItem}>
+        {popularFeedData?.data?.posts?.map(
+          ({ title, content, commentCount, likeCount }, index) => (
+            <Carousel.Item key={index} className={styles.carouselItem}>
               <FeedCard
-                title={title}
-                content={content}
-                commentCount={commentCount}
-                likeCount={likeCount}
+                title={title || ''}
+                content={content || ''}
+                commentCount={commentCount || 0}
+                likeCount={likeCount || 0}
                 onClick={() => {
                   // @TODO 해당 CommunityDetail로 이동
                 }}

--- a/packages/bds-ui/src/components/alert/alert.css.ts
+++ b/packages/bds-ui/src/components/alert/alert.css.ts
@@ -45,8 +45,8 @@ export const alerIconContainer = recipe({
 });
 
 export const alertHeader = style({
-  color: themeVars.color.primary500,
   ...themeVars.fontStyles.head2_b_14,
+  color: themeVars.color.error,
   display: 'flex',
   alignItems: 'center',
 });

--- a/packages/bds-ui/src/components/alert/alert.tsx
+++ b/packages/bds-ui/src/components/alert/alert.tsx
@@ -31,7 +31,7 @@ const Alert = ({
     <div className={styles.alertContainer({ type })}>
       <div className={styles.alerIconContainer({ type })}>
         <Icon
-          color="primary500"
+          color={type === 'info' ? 'error' : 'primary500'}
           name={iconName}
           width={iconSize}
           height={iconSize}

--- a/packages/bds-ui/src/components/carousel/carousel-item.tsx
+++ b/packages/bds-ui/src/components/carousel/carousel-item.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-export interface CarouselItemProps {
+export interface CarouselItemProps
+  extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   style?: React.CSSProperties;
   className?: string;
@@ -12,6 +13,14 @@ export interface CarouselItemProps {
  * @param className
  * @constructor
  */
-export const CarouselItem = ({ children, className }: CarouselItemProps) => {
-  return <div className={className}>{children}</div>;
+export const CarouselItem = ({
+  children,
+  className,
+  ...props
+}: CarouselItemProps) => {
+  return (
+    <div className={className} {...props}>
+      {children}
+    </div>
+  );
 };

--- a/packages/bds-ui/src/components/carousel/carousel.tsx
+++ b/packages/bds-ui/src/components/carousel/carousel.tsx
@@ -27,6 +27,8 @@ import {
 
 import * as styles from './carousel.css';
 
+const ITEM_GAP = 10;
+
 export const CarouselContext = createContext<CarouselContextType | null>(null);
 
 export const useCarouselContext = () => {
@@ -118,7 +120,9 @@ const Carousel = ({
         trackRef.current.parentElement?.getBoundingClientRect();
 
       if (firstSlide && containerRect) {
-        setAutoSlideWidth(firstSlide.getBoundingClientRect().width);
+        const slideWidth = firstSlide.getBoundingClientRect().width;
+
+        setAutoSlideWidth(slideWidth + ITEM_GAP);
         setContainerWidth(containerRect.width);
       }
     }

--- a/packages/bds-ui/src/components/carousel/carousel.tsx
+++ b/packages/bds-ui/src/components/carousel/carousel.tsx
@@ -367,7 +367,7 @@ const Carousel = ({
             transition: isDragging
               ? 'none'
               : 'transform 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94)',
-            cursor: isDragging ? 'grabbing' : 'grab',
+            cursor: isDragging ? 'grabbing' : 'pointer',
             height: maxSlideHeight ? `${maxSlideHeight}px` : 'auto',
             width: isAutoMode ? 'max-content' : '100%',
           }}
@@ -376,13 +376,16 @@ const Carousel = ({
             const itemProps = (
               slide.data as React.ReactElement<CarouselItemProps>
             ).props;
+            const { children, className, ...restProps } = itemProps;
+
             return (
               <div
                 key={slide.key}
-                className={`${styles.slide} ${itemProps.className || ''}`}
+                className={`${styles.slide} ${className || ''}`}
                 style={slide.style}
+                {...restProps}
               >
-                {itemProps.children}
+                {children}
               </div>
             );
           })}

--- a/packages/bds-ui/src/components/carousel/hooks/use-carousel-touch.ts
+++ b/packages/bds-ui/src/components/carousel/hooks/use-carousel-touch.ts
@@ -23,12 +23,16 @@ export const useCarouselTouch = ({
   const [isDragging, setIsDragging] = useState(false);
   const [startX, setStartX] = useState(0);
   const [dragOffset, setDragOffset] = useState(0);
+  const [hasMoved, setHasMoved] = useState(false);
+  const [clickTarget, setClickTarget] = useState<EventTarget | null>(null);
 
   /** 누를 때 시작 위치 저장 */
   const handlePointerDown = useCallback((e: PointerEvent<Element>) => {
     setIsDragging(true);
     setStartX(e.clientX);
     setDragOffset(0);
+    setHasMoved(false);
+    setClickTarget(e.target);
     setIsHovered(true);
     e.currentTarget.setPointerCapture(e.pointerId);
   }, []);
@@ -40,43 +44,61 @@ export const useCarouselTouch = ({
         return;
       }
 
-      const diff = startX - e.clientX;
+      const dragDiff = startX - e.clientX;
+      const diff = Math.abs(dragDiff);
+
+      if (diff > 10) {
+        setHasMoved(true);
+      }
+
       const containerWidth = e.currentTarget.clientWidth;
-      const dragOffsetPercent = (diff / containerWidth) * 100;
+      const dragOffsetPercent = (dragDiff / containerWidth) * 100;
       setDragOffset(dragOffsetPercent);
     },
     [isDragging, startX],
   );
 
-  /** 뗄 때 드래그 거리 기준으로 컨트롤러를 통해 새로운 상태 계산 */
+  /** 뗄 때 드래그 거리 기준으로 컨트롤러를 통해 새로운 상태 계산
+   * - 드래그 했는지 : true => 드래그 거리 기준으로 슬라이드 변경
+   * - 드래그 안 했는지 : false => 클릭 이벤트로 간주하여 원래 타겟 클릭
+   */
   const handlePointerUp = useCallback(
     (e: PointerEvent<Element>) => {
       if (!isDragging || !controller) {
         return;
       }
+      if (hasMoved) {
+        const diff = startX - e.clientX;
+        const containerWidth = e.currentTarget.clientWidth || 1;
+        const dragOffsetPercent = (diff / containerWidth) * 100;
 
-      const diff = startX - e.clientX;
-      const containerWidth = e.currentTarget.clientWidth || 1;
-      const dragOffsetPercent = (diff / containerWidth) * 100;
+        const newState = controller.handleDragEnd(
+          carouselState,
+          dragOffsetPercent,
+          {
+            isAutoPlay: autoPlay,
+          },
+        );
 
-      const newState = controller.handleDragEnd(
-        carouselState,
-        dragOffsetPercent,
-        {
-          isAutoPlay: autoPlay,
-        },
-      );
-
-      onStateUpdate(newState);
+        onStateUpdate(newState);
+      } else {
+        if (clickTarget && clickTarget instanceof HTMLElement) {
+          clickTarget.click();
+        }
+      }
 
       setIsDragging(false);
       setDragOffset(0);
+      setHasMoved(false);
+      setClickTarget(null);
       setIsHovered(false);
       e.currentTarget.releasePointerCapture(e.pointerId);
     },
     [
       isDragging,
+      hasMoved,
       startX,
+      clickTarget,
       controller,
       carouselState,
       autoPlay,
@@ -101,6 +123,7 @@ export const useCarouselTouch = ({
   return {
     isHovered,
     isDragging,
+    hasMoved,
     dragOffset,
     handlePointerDown,
     handlePointerMove,

--- a/packages/bds-ui/src/components/carousel/types/types.ts
+++ b/packages/bds-ui/src/components/carousel/types/types.ts
@@ -29,6 +29,7 @@ export interface UseCarouselTouchProps {
 export interface UseCarouselTouchReturn {
   isHovered: boolean;
   isDragging: boolean;
+  hasMoved: boolean;
   dragOffset: number;
   handlePointerDown: (e: PointerEvent<Element>) => void;
   handlePointerMove: (e: PointerEvent<Element>) => void;


### PR DESCRIPTION
## 📌 Summary

> - #455 

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._
커뮤니티 인기 게시글 api를 연결합니다.

## 📚 Tasks

- 커뮤니티 인기 게시글 get api 연결
- 이 pr에서 작업한 다른 것들
  - 카테고리 칩 오른쪽 여백 제거
  - 전체적인 인기 게시글 컴포넌트 스타일 수정
  - alert 컴포넌트 title 색상 변경

### 인기 게시글 api
파라미터로 넘겨야 하는 파라미터가 현재 2개가 있어요 (둘 다 필수 파라미터는 아님)

<img width="475" height="149" alt="image" src="https://github.com/user-attachments/assets/be758cae-79bd-4a3e-ba18-167ccd3d6a6e" />

size: 인기 게시글의 개수를 넘김
sort: rank 또는 random을 넘김
  - rank: 인기 게시글 상위 20개 항목 순서대로 반환 (size의 갯수만큼)
  - random: 상위 20개 항목 중 랜덤으로 반환 (size의 갯수만큼)
 
둘 다 필수 파라미터 값은 아니에요 - size의 default 값은 5 / sort의 default 값은 rank

인기 게시글이 3개로 고정되어 있어서 왜 파라미터로 넘겨야하는 하는지에 대한 궁금증이 생겨서 물어봤는데 추후 확장성면에서 생각했을 때 파라미터로 넘기는게 좋다고 생각해서 이렇게 구현하였다고 답변을 들었어요.
(size의 default가 3이 아닌 5인 이유는 딱히 없다고 해요)

<br/>

### api 연결 이외에 작업한 것들

> 카테고리 chip 스크롤 여백 수정

<img width="574" height="98" alt="image" src="https://github.com/user-attachments/assets/0d7512f1-748c-4d9e-a302-0d6efb9232f9" />

피그마에는 chip 오른쪽 스크롤 부분에 여백이 없더라고요..
<br/>

<img width="390" height="290" alt="image" src="https://github.com/user-attachments/assets/2b2a315b-5976-471b-9ea2-e9f43dc73dd3" /> 

변경하기 전에는 오른쪽에 padding으로 인해 여백이 존재했는데
<br/>

<img width="390" height="290" alt="image" src="https://github.com/user-attachments/assets/7587bec9-d5e7-4f29-954b-215c3912165a" />

변경 이후에는 피그마처럼 오른쪽 여백을 제거했어요.

<br/>

> 인기 게시글 컴포넌트 전체적인 스타일 수정

- `좋아요, 댓글` 아이콘 색상이 검정색이 아니라 gray600으로 지정되어 있더라고요. 이 부분 수정하였습니다.
- 인기 게시글의 contents가 한줄일 때에 `좋아요, 댓글` 위치가 변하더라고요. 그래서 `좋아요, 댓글` 위치가 아래에 위치하도록 수정했습니다.
- 인기 게시글의 title이 길어지면 줄바꿈이 되더라고요. 그래서  contents뿐만 아니라 title 또한 줄이 넘어가면 …으로 대체했습니다.

<details>
<summary>변경한 부분 확인</summary>
<br/>

변경 전 / 변경 후
<img width="256" height="138" alt="image" src="https://github.com/user-attachments/assets/be100619-8a4c-40e7-8a3b-fd199e6bf617" /> <img width="259" height="138" alt="image" src="https://github.com/user-attachments/assets/c6916f6d-55c7-479f-83d5-b98e57da7df5" />

⬆️ 좋아요, 댓글 위치가 아래에 위치하도록 수정
<br/>

변경 전 / 변경 후
<img width="261" height="139" alt="image" src="https://github.com/user-attachments/assets/55e641f5-4fe9-478e-8a6e-a717953c6f26" /> <img width="260" height="140" alt="image" src="https://github.com/user-attachments/assets/7b6fd244-728b-4f0f-ade6-5149df6e71d3" />

⬆️ contents뿐만 아니라 title 또한 줄이 넘어가면 …으로 대체
</details>


<br/>

> alert 타이틀 색상 변경

간단한 작업이라고 생각해서 여기서 작업했어요.. 근데 작은 작업들을 하다보니까 너무 자잘한 것들을 많이 수정한 것 같네요.......
<img width="392" height="127" alt="image" src="https://github.com/user-attachments/assets/d5a022cb-95cb-449d-a0ad-c129f35cada7" /> <img width="397" height="127" alt="image" src="https://github.com/user-attachments/assets/1ea3b6ed-73f2-4f7a-8ea9-1027ecddcede" />

약간의 이슈 ⇒ `color: themeVars.color.gradientError`가 적용이 안되어서 `color: themeVars.color.error`로 색상을 지정했어요.
color 속성은 단색깔만 적용이 되어서라고 하네요..  icon도 마찬가지에요..

### 캐러셀 onClick 문제

~~캐러셀에서 캐러셀 item에 해당하는 컴포넌트에 onClick 함수를 줘서 함수를 실행시키고 싶은데 안되는 것 같아요...~~
~~carousel-item.tsx 파일에 onClick 관련 props가 없고 캐러셀 트랙에 붙은 드래그 처리때문에 그런걸까요..?~~
=> **자비로운 민정님께서 해결해주셨어요**

~~(그리고 캐러셀 스크롤할 때 1rem만큼씩 밀리는 것 같습니다..ㅜ)~~ -> **자비로운 민정님께서 해결해주셨어요**


## 👀 To Reviewer

원래는 스타일 조금만 수정하려고 했는데 자잘자잘하게 많이 해서 api 연결 PR이 아니게 된 것 같네요...😭

- ~~지금 인기 게시글을 클릭하면 해당 디테일 페이지로 이동해야하는데 onClick이 작동하지 않아요ㅜㅜㅜ 
민정님의 의견과 도움 기다리고 있겠습니다...~~ => **자비로운 민정님께서 해결해주셨어요**

<!--
## 🕶️ Requirements Checklist

- [ ]

(기능 명세서상 내용을 복사해서 테스트해주세요)
-->


## 📸 Screenshot


https://github.com/user-attachments/assets/f4305fc2-af0c-4006-901c-ccc0fa8f84e5



