### PR TITLE
Fix(client): 캐러셀 Click / Drag 상태를 분간하는 처리에 autoPlay 옵션 분기

### DIFF
--- a/apps/client/src/widgets/home/components/info-section/recommended-info-section.tsx
+++ b/apps/client/src/widgets/home/components/info-section/recommended-info-section.tsx
@@ -77,7 +77,7 @@ export const RecommendedInfoSection = ({
 
       <Carousel slidesPerView={4.5} autoPlay className={styles.homeCardList}>
         {reportSummary.statuses?.map((card, index) => (
-          <Carousel.Item key={index} style={{ width: 'auto' }}>
+          <Carousel.Item key={index}>
             <HomeCard
               icon={
                 <img

--- a/packages/bds-ui/src/components/carousel/hooks/use-carousel-touch.ts
+++ b/packages/bds-ui/src/components/carousel/hooks/use-carousel-touch.ts
@@ -16,7 +16,6 @@ export const useCarouselTouch = ({
   carouselState,
   pauseOnHover,
   autoPlay,
-  infinite,
   onStateUpdate,
 }: UseCarouselTouchProps): UseCarouselTouchReturn => {
   const [isHovered, setIsHovered] = useState(false);

--- a/packages/bds-ui/src/components/carousel/hooks/use-carousel-touch.ts
+++ b/packages/bds-ui/src/components/carousel/hooks/use-carousel-touch.ts
@@ -27,15 +27,21 @@ export const useCarouselTouch = ({
   const [clickTarget, setClickTarget] = useState<EventTarget | null>(null);
 
   /** 누를 때 시작 위치 저장 */
-  const handlePointerDown = useCallback((e: PointerEvent<Element>) => {
-    setIsDragging(true);
-    setStartX(e.clientX);
-    setDragOffset(0);
-    setHasMoved(false);
-    setClickTarget(e.target);
-    setIsHovered(true);
-    e.currentTarget.setPointerCapture(e.pointerId);
-  }, []);
+  const handlePointerDown = useCallback(
+    (e: PointerEvent<Element>) => {
+      setIsDragging(true);
+      setStartX(e.clientX);
+      setDragOffset(0);
+
+      if (!autoPlay) {
+        setHasMoved(false);
+        setClickTarget(e.target);
+      }
+
+      e.currentTarget.setPointerCapture(e.pointerId);
+    },
+    [autoPlay],
+  );
 
   /** 움직일 때 드래그 오프셋 계산 */
   const handlePointerMove = useCallback(
@@ -47,7 +53,7 @@ export const useCarouselTouch = ({
       const dragDiff = startX - e.clientX;
       const diff = Math.abs(dragDiff);
 
-      if (diff > 10) {
+      if (!autoPlay && diff > 10) {
         setHasMoved(true);
       }
 
@@ -55,19 +61,41 @@ export const useCarouselTouch = ({
       const dragOffsetPercent = (dragDiff / containerWidth) * 100;
       setDragOffset(dragOffsetPercent);
     },
-    [isDragging, startX],
+    [isDragging, startX, autoPlay],
   );
 
   /** 뗄 때 드래그 거리 기준으로 컨트롤러를 통해 새로운 상태 계산
-   * - 드래그 했는지 : true => 드래그 거리 기준으로 슬라이드 변경
-   * - 드래그 안 했는지 : false => 클릭 이벤트로 간주하여 원래 타겟 클릭
+   * - autoPlay=false: 드래그 여부에 따라 슬라이드 변경 or 클릭 이벤트 처리
+   * - autoPlay=true: 항상 드래그로 처리 (onClick 무시)
    */
+
   const handlePointerUp = useCallback(
     (e: PointerEvent<Element>) => {
       if (!isDragging || !controller) {
         return;
       }
-      if (hasMoved) {
+
+      if (!autoPlay) {
+        if (hasMoved) {
+          const diff = startX - e.clientX;
+          const containerWidth = e.currentTarget.clientWidth || 1;
+          const dragOffsetPercent = (diff / containerWidth) * 100;
+
+          const newState = controller.handleDragEnd(
+            carouselState,
+            dragOffsetPercent,
+            {
+              isAutoPlay: false,
+            },
+          );
+
+          onStateUpdate(newState);
+        } else {
+          if (clickTarget && clickTarget instanceof HTMLElement) {
+            clickTarget.click();
+          }
+        }
+      } else {
         const diff = startX - e.clientX;
         const containerWidth = e.currentTarget.clientWidth || 1;
         const dragOffsetPercent = (diff / containerWidth) * 100;
@@ -76,22 +104,21 @@ export const useCarouselTouch = ({
           carouselState,
           dragOffsetPercent,
           {
-            isAutoPlay: autoPlay,
+            isAutoPlay: true,
           },
         );
 
         onStateUpdate(newState);
-      } else {
-        if (clickTarget && clickTarget instanceof HTMLElement) {
-          clickTarget.click();
-        }
       }
 
       setIsDragging(false);
       setDragOffset(0);
-      setHasMoved(false);
-      setClickTarget(null);
-      setIsHovered(false);
+
+      if (!autoPlay) {
+        setHasMoved(false);
+        setClickTarget(null);
+      }
+
       e.currentTarget.releasePointerCapture(e.pointerId);
     },
     [
@@ -102,12 +129,10 @@ export const useCarouselTouch = ({
       controller,
       carouselState,
       autoPlay,
-      infinite,
       onStateUpdate,
     ],
   );
 
-  /** 호버 상태 관리 */
   const handleMouseEnter = useCallback(() => {
     if (pauseOnHover) {
       setIsHovered(true);


### PR DESCRIPTION
## 📌 Summary

> close #470

Carousel 컴포넌트에서 무한 스크롤 시 슬라이드가 사라지는 문제를 해결했습니다. 문제의 근본 원인은 Carousel.Item에 직접 주입된 style={{ width: 'auto' }}가 가상화 로직의 width 계산을 방해했기 때문입니다.


## 🚨🚨 문제 상황 🚨🚨

autoPlay가 적용된 무한 캐러셀에서 슬라이드가 이동하다가 특정 시점에 아이템이 사라지거나 순서가 뒤바뀌는 문제가 발생했어요.

재현 조건:
- slidesPerView={4.5} (분수)
- autoPlay={true}
- infinite={true} (무한 스크롤)
- <Carousel.Item style={{ width: 'auto' }}>로 사용

https://github.com/user-attachments/assets/89ec5223-8533-422f-a809-b5092453ea50


## 원인 분석

### 1차 원인 : onClick 이벤트 처리를 위한 변경사항
[혜린이 PR](https://github.com/team-bofit/bofit-client/pull/461) 에서 발생한 문제를 해결하기 위해 잠깐 침투해서 급하게 처리했던 작업입니다.

> ## OnClick Event 처리 되지 않는 문제 해결 공유 
> 
> ### 문제 상황
> 
> Carousel 컴포넌트에서 <Carousel.Item onClick={...}>을 사용할 때 클릭 이벤트가 작동하지 않는 문제
> 
> ### 원인 
> 
> Pointer Events가 클릭 이벤트를 가로막음
> -> 드래그를 구현하기 위해서 Pointer 이벤트를 몇개 연결했는데, Pointer Event 는 Mouse Events 보다 우선순위가 높아서 onClick(=Mouse Event) 이벤트가 발생하지 않았어요. 
> -> 유저가 클릭 시 setPointerCapture 를 사용하는데, 이 이유로 포인터 이벤트가 해당 요소에 고정되어 내부 요소 클릭이 차단되기 때문이에요. 
> 
> ### 해결 
> 
> > _**드래그 하지 않았다면, 클릭 이벤트를 발생시킨다**_ 라는 기본적인 동작을 주입하고자 했어요
> 이를 위해서 다음과 같은 룰을 정했습니다. 
> 
> 1. 포인터 DOWN 시 ->  클릭된 요소를 저장 setPointerCapture()
> 2. 포인터 이동 시 -> 드래그 계산
> 3. **포인터 UP 시 ->** 
> - **drag 여부가 true 이면 슬라이드 이동**
> -  **drag 여부가 false 이면 캡쳐한 요소에 .click() 호출**

이 작업에서 <Carousel.Item> 의 Props 로 받아지는 HTMLAttributes 의 restProps 들을 실제로 
캐러셀 아이템들에 적용하는 코드를 추가했습니다.  [@commit](https://github.com/team-bofit/bofit-client/pull/461/commits/8b01a96317ac94b970929e5546ff3dcb5854c157)

```ts
// carousel.tsx
{displaySlides.map((slide) => {
  const itemProps = (slide.data as React.ReactElement<CarouselItemProps>).props;
  const { children, className, ...restProps } = itemProps;

  return (
    <div
      key={slide.key}
      className={`${styles.slide} ${className || ''}`}
      style={slide.style}
      {...restProps}  // 🚨 여기서 문제 발생
    >
      {children}
    </div>
  );
})}
```

사용처에서 다음과 같이 style prop을 직접 주입하고 있었습니다

```ts
<Carousel slidesPerView={4.5} autoPlay className={styles.homeCardList}>
  {reportSummary.statuses?.map((card, index) => (
    <Carousel.Item key={index} style={{ width: 'auto' }}> // 여기 !
      <HomeCard
        icon={
          <img
            src={targetToIconMap.get(card.target || '')}
            alt={card.target || ''}
            className={styles.homeCardIcon}
          />
        }
        title={card.target || ''}
        status={card.status as StatusType}
      />
    </Carousel.Item>
  ))}
</Carousel>
```

[ 여기서 볼 수 있는 문제 발생 과정 ] 
1. 가상화 로직(useCarouselVirtual)에서 각 슬라이드의 style.width를 계산하여 할당
2. 하지만 {...restProps}로 인해 사용자가 전달한 style={{ width: 'auto' }}가 가상화 계산값을 덮어씀
3. 무한 스크롤에서 position: 'absolute', left: 'X%'로 배치되는데, width가 깨지면서 위치 계산이 틀어짐
4. 슬라이드가 사라지거나 순서가 뒤바뀌는 현상 발생


그래서 해당 style 주입 코드를 제거했습니다. **(=> ✅ 요것을 지우니 해결되었습니다. 근본적인 원인이었어요)**




###  2차 원인: autoPlay 모드에서의 onClick/Drag 이슈

onclick 이 되지 않는 문제를 해결하다가 (혜린이 PR) 
유저가 드래그 중인지 / 아닌지 를 파악하여 코드 분기처리를 했는데

사실 autoPlay 의 경우 onClick 해서 Navigate 를 하는 등의 행위가 필요 없고, 드래그 역할이 필요합니다. 
그래서 이 autoPlay 에 대해 분기처리가 필요했어요.

1. handlePointerDown - autoPlay=false일 때만 클릭 추적
2. handlePointerMove - autoPlay=false일 때만 드래그 감지
3. handlePointerUp - autoPlay에 따라 분기 처리
   * - autoPlay=false: 드래그 여부에 따라 슬라이드 변경 or 클릭 이벤트 처리
   * - autoPlay=true: 항상 드래그로 처리 (onClick 무시)
 
```ts
// autoPlay=false: 드래그 여부 체크 → onClick or 슬라이드 변경
if (!autoPlay) {
  if (hasMoved) {
    // 드래그한 경우: 슬라이드 변경
    const newState = controller.handleDragEnd(...);
    onStateUpdate(newState);
  } else {
    // 드래그하지 않은 경우: 클릭 이벤트 발생
    if (clickTarget && clickTarget instanceof HTMLElement) {
      clickTarget.click();
    }
  }
} else {
  // autoPlay=true: 항상 드래그로 처리 (onClick 무시)
  const newState = controller.handleDragEnd(...);
  onStateUpdate(newState);
}

```

이런 식으로 코드를 작성해서,
autoPlay 가 true 일 때는 onClick 이벤트와는 무관하게 drag 에 집중하고,
autoPlay 가 false 일 때는 onClick 에 함수가 들어오면 그 onClick 이 가능하고, 드래그 시 드래그도 되도록 
동작하는 것에 집중해서 구현했습니다. **-> 무한 스크롤에서 ✅ 스크롤 이슈가 해결되었습니다.**
 
home 캐러셀 2개와
커뮤니티 홈 캐러셀이 잘 동작하는 것을 확인 했습니다. -> 요고 한번씩 리뷰할 때 더블체크 해주시면 감사합니다 !! 💭