### PR TITLE
Fix(client): 디테일 페이지 진입 후 이전버튼 클릭 시 이전상태 유지되도록 수정

### DIFF
--- a/apps/client/src/widgets/community/components/search/search.tsx
+++ b/apps/client/src/widgets/community/components/search/search.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, KeyboardEvent, useState } from 'react';
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { useNavigate } from 'react-router';
+import { useNavigate, useSearchParams } from 'react-router';
 
 import { Chip, Input } from '@bds/ui';
 import { Icon } from '@bds/ui/icons';
@@ -18,8 +18,9 @@ import * as styles from './search.css';
 const LOCAL_STORAGE_KEY = 'recentSearch';
 
 const Search = () => {
-  const [inputValue, setInputValue] = useState<string>('');
-  const [queryValue, setQueryValue] = useState<string>('');
+  const [params, setParams] = useSearchParams();
+  const keyword = params.get('keyword') ?? '';
+  const [inputValue, setInputValue] = useState<string>(() => keyword);
 
   const { getLocalStorage, addLocalStorage, deleteLocalStorage } =
     LocalStorage(LOCAL_STORAGE_KEY);
@@ -28,8 +29,8 @@ const Search = () => {
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteQuery({
-      ...COMMUNITY_QUERY_OPTIONS.SEARCH(queryValue),
-      enabled: !!queryValue,
+      ...COMMUNITY_QUERY_OPTIONS.SEARCH(keyword),
+      enabled: !!keyword,
     });
 
   const handleChangeSearch = (e: ChangeEvent<HTMLInputElement>) => {
@@ -44,7 +45,7 @@ const Search = () => {
     if (!submitValue) {
       return;
     }
-    setQueryValue(submitValue);
+    setParams({ keyword: submitValue });
     addLocalStorage(submitValue);
     setRecentSearch(getLocalStorage());
   };
@@ -55,8 +56,8 @@ const Search = () => {
   };
 
   const handleRecentSearch = (history: string) => {
+    setParams({ keyword: history });
     setInputValue(history);
-    setQueryValue(history);
     addLocalStorage(history);
     setRecentSearch(getLocalStorage());
   };
@@ -82,7 +83,7 @@ const Search = () => {
         onKeyDown={handleKeyDown}
         bgColor="background"
         icon={<Icon name="search" color="gray300" />}
-        hasClearButton={true}
+        hasClearButton
       />
       <div className={styles.searchHistoryContainer}>
         <p className={styles.searchHistoryTitle}>최근 검색어</p>

--- a/apps/client/src/widgets/community/components/search/search.tsx
+++ b/apps/client/src/widgets/community/components/search/search.tsx
@@ -86,7 +86,9 @@ const Search = () => {
         hasClearButton
       />
       <div className={styles.searchHistoryContainer}>
-        <p className={styles.searchHistoryTitle}>최근 검색어</p>
+        {recentSearch.length > 0 && (
+          <p className={styles.searchHistoryTitle}>최근 검색어</p>
+        )}
         <div className={styles.chipContainer}>
           {recentSearch.map((history: string) => (
             <Chip

--- a/packages/bds-ui/src/components/input/input.tsx
+++ b/packages/bds-ui/src/components/input/input.tsx
@@ -78,6 +78,8 @@ const Input = ({
       ...e,
       target: { value: '' } as HTMLInputElement,
     } as unknown as React.ChangeEvent<HTMLInputElement>);
+
+    inputRef.current?.focus();
   };
 
   return (


### PR DESCRIPTION
## 📌 Summary

> - #469 

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

## 📚 Tasks

- put 컴포넌트에 inputClear 함수 활성화되면 자동 포커싱하기
- searchParams 사용해서 해결
- 검색어 있을 때에만 최근검색어 등장시키기


## 👀 To Reviewer

- input 컴포넌트의 inputClear 함수에다가 자동 포커싱하는 작업을 했습니다. => input에 x를 눌러서 input 값을 삭제한 다음에는 바로 입력창이 포커싱되는게 UX가 더 자연스럽다고 생각해서 했습니다..

- 피그마 보니 검색어가 있을 때에만 최근 검색어라는 텍스트가 등장해서 이 부분도 함께 수정했어요
<!--
## 🕶️ Requirements Checklist
- [ ]

(기능 명세서상 내용을 복사해서 테스트해주세요)
-->

## 📸 Screenshot

수정 전

https://github.com/user-attachments/assets/41f21f04-5e92-4a51-9dc9-32ecc1df5e9a

<br/>

수정 후

https://github.com/user-attachments/assets/8b1339e7-cb3e-40e6-9063-67c8f4ab00dc


