### PR TITLE
Feat(client): 커뮤니티 글 수정 

### DIFF
--- a/apps/client/src/pages/community/community-edit/community-edit.css.ts
+++ b/apps/client/src/pages/community/community-edit/community-edit.css.ts
@@ -1,9 +1,10 @@
 import { style } from '@vanilla-extract/css';
 
 export const container = style({
+  overflowY: 'auto',
   display: 'flex',
+  height: '100dvh',
   flexDirection: 'column',
-  height: '100vh',
   gap: '3.6rem',
 });
 
@@ -31,4 +32,23 @@ export const postTitle = style({
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'space-between',
+});
+
+export const imageContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.2rem',
+  padding: '1.2rem 0 5.5rem 0',
+});
+
+export const imageItem = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-end',
+});
+
+export const postImage = style({
+  width: '100%',
+  objectFit: 'cover',
+  borderRadius: '12px',
 });

--- a/apps/client/src/pages/community/community-edit/community-edit.tsx
+++ b/apps/client/src/pages/community/community-edit/community-edit.tsx
@@ -111,7 +111,7 @@ const CommunityEdit = () => {
 
     const uploadedUrls = extractS3Urls(data.presignedUrls).map((url, idx) => ({
       imageUrl: url,
-      sequence: updatedImages.length + idx + 1,
+      sequence: updatedImages.length + idx,
     }));
 
     setUpdatedImages((prev) => [...prev, ...uploadedUrls]);

--- a/apps/client/src/pages/community/community-edit/community-edit.tsx
+++ b/apps/client/src/pages/community/community-edit/community-edit.tsx
@@ -34,15 +34,15 @@ const CommunityEdit = () => {
   };
   const [title, setTitle] = useState(state.title);
   const [content, setContent] = useState(state.content);
+
   const getInitialCategory = () => {
-    if (!state.category) {
-      return null;
-    }
-    const matchedOption = categoryOptions.find(
-      (option) => option.value === state.category?.category,
+    return (
+      categoryOptions.find(
+        (option) => option.value === state.category?.category,
+      ) ?? null
     );
-    return matchedOption ?? null;
   };
+
   const [category, setCategory] = useState(getInitialCategory);
   const { isErrorState } = useLimitedInput(LIMIT_SHORT_TEXT, title.length);
 
@@ -76,12 +76,12 @@ const CommunityEdit = () => {
     });
   };
 
-  const isTitleValid = title.trim().length > 0;
-  const isContentValid = content.trim().length > 0;
-  const isCategoryValid = Boolean(category?.value);
-
   const isDisabled =
-    !(isTitleValid && isContentValid && isCategoryValid) || isPending;
+    !(
+      title.trim().length > 0 &&
+      content.trim().length > 0 &&
+      Boolean(category?.value)
+    ) || isPending;
 
   const handleGoBack = () => {
     navigate(-1);

--- a/apps/client/src/pages/community/community-edit/community-edit.tsx
+++ b/apps/client/src/pages/community/community-edit/community-edit.tsx
@@ -21,6 +21,10 @@ import {
   COMMUNITY_MUTATION_OPTIONS,
   COMMUNITY_QUERY_OPTIONS,
 } from '@shared/api/domain/community/queries';
+import {
+  MUTATION_QUERY_OPTIONS,
+  uploadImageToS3,
+} from '@shared/api/domain/queries';
 import { COMMUNITY_QUERY_KEY } from '@shared/api/keys/query-key';
 import {
   LIMIT_LONG_TEXT,
@@ -28,6 +32,7 @@ import {
 } from '@shared/constants/text-limits';
 import { useLimitedInput } from '@shared/hooks/use-limited-input';
 import { routePath } from '@shared/router/path';
+import { extractS3Urls } from '@shared/utils/utils';
 
 import * as styles from './community-edit.css';
 
@@ -54,6 +59,10 @@ const CommunityEdit = () => {
     },
   });
 
+  const { mutate: postImageUploadMutate } = useMutation({
+    ...MUTATION_QUERY_OPTIONS.POST_IMAGE(),
+  });
+
   if (!feedDetailData) {
     throw new Error(
       '글 수정 페이지에서 원본 피드 데이터를 불러오지 못했습니다.',
@@ -65,20 +74,62 @@ const CommunityEdit = () => {
   const [category, setCategory] = useState(
     feedDetailData?.category?.category || '',
   );
-  const [uploadedImages, setUploadedImages] = useState<
+  const [newImages, setNewImages] = useState<
     { file: File; previewUrl: string }[]
   >([]);
   const [deletedImageIds, setDeletedImageIds] = useState<number[]>([]);
+  const [updatedImages, setUpdatedImages] = useState<
+    { id?: number; imageUrl: string; sequence: number }[]
+  >(
+    () =>
+      feedDetailData.imageUrl?.filter(isValidImage).map((img, index) => ({
+        id: img.imageId,
+        imageUrl: img.imageUrl,
+        sequence: index + 1,
+      })) ?? [],
+  );
   const { isErrorState } = useLimitedInput(LIMIT_SHORT_TEXT, title.length);
 
-  const handlePutFeed = () => {
+  const handleUploadNewImages = async () => {
+    if (newImages.length === 0) {
+      return [];
+    }
+
+    const data = await new Promise<{ presignedUrls: string[] }>(
+      (resolve, reject) =>
+        postImageUploadMutate(
+          newImages.map((item) => item.file.type),
+          { onSuccess: resolve, onError: reject },
+        ),
+    );
+
+    await Promise.all(
+      data.presignedUrls.map((url, idx) =>
+        uploadImageToS3(url, newImages[idx].file),
+      ),
+    );
+
+    const uploadedUrls = extractS3Urls(data.presignedUrls).map((url, idx) => ({
+      imageUrl: url,
+      sequence: updatedImages.length + idx + 1,
+    }));
+
+    setUpdatedImages((prev) => [...prev, ...uploadedUrls]);
+    setNewImages([]);
+
+    return uploadedUrls;
+  };
+
+  const handlePutFeed = async () => {
+    const newUploadedImages = await handleUploadNewImages();
+
     mutate({
       body: {
         newTitle: title,
         newContent: content,
         newCategory: category,
         deleteImageIds: deletedImageIds,
-        updatedImages: [],
+        updatedImages: [...updatedImages, ...newUploadedImages],
       },
     });
   };
@@ -108,11 +159,11 @@ const CommunityEdit = () => {
       file,
       previewUrl: URL.createObjectURL(file),
     }));
-    setUploadedImages((prev) => [...prev, ...newImages]);
+    setNewImages((prev) => [...prev, ...newImages]);
   };
 
   const handleRemoveNewImage = (urlToRemove: string) => {
-    setUploadedImages((prev) =>
+    setNewImages((prev) =>
       prev.filter((item) => item.previewUrl !== urlToRemove),
     );
   };
@@ -142,7 +193,6 @@ const CommunityEdit = () => {
             }
             onClick={() => {
               handlePutFeed();
-              handleGoBack();
             }}
           >
             완료
@@ -185,25 +235,28 @@ const CommunityEdit = () => {
           <Title fontStyle="eb_md">내용</Title>
           <CommunityLine value={content} onChange={handleContentChange} />
           {(feedDetailData.imageUrl?.some(isValidImage) ||
-            uploadedImages.length > 0) && (
+            newImages.length > 0) && (
             <div className={styles.imageContainer}>
-              {feedDetailData.imageUrl?.filter(isValidImage).map((orgImage) => (
-                <div key={orgImage.imageId} className={styles.imageItem}>
-                  <img
-                    className={styles.postImage}
-                    src={orgImage.imageUrl}
-                    alt="uploaded"
-                  />
-                  <TextButton
-                    color="black"
-                    size="sm"
-                    onClick={() => handleRemoveOriginImage(orgImage.imageId)}
-                  >
-                    삭제
-                  </TextButton>
-                </div>
-              ))}
-              {uploadedImages.map((image) => (
+              {feedDetailData.imageUrl
+                ?.filter(isValidImage)
+                .filter((img) => !deletedImageIds.includes(img.imageId))
+                .map((orgImage) => (
+                  <div key={orgImage.imageId} className={styles.imageItem}>
+                    <img
+                      className={styles.postImage}
+                      src={orgImage.imageUrl}
+                      alt="uploaded"
+                    />
+                    <TextButton
+                      color="black"
+                      size="sm"
+                      onClick={() => handleRemoveOriginImage(orgImage.imageId)}
+                    >
+                      삭제
+                    </TextButton>
+                  </div>
+                ))}
+              {newImages.map((image) => (
                 <div key={image.previewUrl} className={styles.imageItem}>
                   <img
                     className={styles.postImage}

--- a/apps/client/src/pages/community/community-edit/community-edit.tsx
+++ b/apps/client/src/pages/community/community-edit/community-edit.tsx
@@ -9,11 +9,13 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { Input, Navigation, TextButton, Title } from '@bds/ui';
 import { Icon } from '@bds/ui/icons';
 
+import CommunityImageUploader from '@widgets/community/components/community-image-uploader/community-image-uploader';
 import CommunityLine from '@widgets/community/components/community-line/community-line';
 import FilterDropDown from '@widgets/community/components/filter-dropdown/filter-dropdown';
 import { categoryOptions } from '@widgets/community/configs/category-config';
 import { PLACEHOLDER } from '@widgets/community/constant/input-placeholder';
 import { CategoryType } from '@widgets/community/types/category-type';
+import { isValidImage } from '@widgets/community/utils/type-guard';
 
 import {
   COMMUNITY_MUTATION_OPTIONS,
@@ -52,11 +54,21 @@ const CommunityEdit = () => {
     },
   });
 
+  if (!feedDetailData) {
+    throw new Error(
+      '글 수정 페이지에서 원본 피드 데이터를 불러오지 못했습니다.',
+    );
+  }
+
   const [title, setTitle] = useState(feedDetailData?.title || '');
   const [content, setContent] = useState(feedDetailData?.content || '');
   const [category, setCategory] = useState(
     feedDetailData?.category?.category || '',
   );
+  const [uploadedImages, setUploadedImages] = useState<
+    { file: File; previewUrl: string }[]
+  >([]);
+  const [deletedImageIds, setDeletedImageIds] = useState<number[]>([]);
   const { isErrorState } = useLimitedInput(LIMIT_SHORT_TEXT, title.length);
 
   const handlePutFeed = () => {
@@ -65,7 +77,7 @@ const CommunityEdit = () => {
         newTitle: title,
         newContent: content,
         newCategory: category,
-        deleteImageIds: [],
+        deleteImageIds: deletedImageIds,
         updatedImages: [],
       },
     });
@@ -89,6 +101,24 @@ const CommunityEdit = () => {
 
   const handleCategory = (option: CategoryType) => {
     setCategory(option.value);
+  };
+
+  const handleImageChange = (files: FileList) => {
+    const newImages = Array.from(files).map((file) => ({
+      file,
+      previewUrl: URL.createObjectURL(file),
+    }));
+    setUploadedImages((prev) => [...prev, ...newImages]);
+  };
+
+  const handleRemoveNewImage = (urlToRemove: string) => {
+    setUploadedImages((prev) =>
+      prev.filter((item) => item.previewUrl !== urlToRemove),
+    );
+  };
+
+  const handleRemoveOriginImage = (imageId: number) => {
+    setDeletedImageIds((prev) => [...prev, imageId]);
   };
 
   return (
@@ -154,8 +184,46 @@ const CommunityEdit = () => {
         <div className={styles.postContent}>
           <Title fontStyle="eb_md">내용</Title>
           <CommunityLine value={content} onChange={handleContentChange} />
+          {(feedDetailData.imageUrl?.some(isValidImage) ||
+            uploadedImages.length > 0) && (
+            <div className={styles.imageContainer}>
+              {feedDetailData.imageUrl?.filter(isValidImage).map((orgImage) => (
+                <div key={orgImage.imageId} className={styles.imageItem}>
+                  <img
+                    className={styles.postImage}
+                    src={orgImage.imageUrl}
+                    alt="uploaded"
+                  />
+                  <TextButton
+                    color="black"
+                    size="sm"
+                    onClick={() => handleRemoveOriginImage(orgImage.imageId)}
+                  >
+                    삭제
+                  </TextButton>
+                </div>
+              ))}
+              {uploadedImages.map((image) => (
+                <div key={image.previewUrl} className={styles.imageItem}>
+                  <img
+                    className={styles.postImage}
+                    src={image.previewUrl}
+                    alt="preview"
+                  />
+                  <TextButton
+                    color="black"
+                    size="sm"
+                    onClick={() => handleRemoveNewImage(image.previewUrl)}
+                  >
+                    삭제
+                  </TextButton>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       </div>
+      <CommunityImageUploader onChange={handleImageChange} />
     </div>
   );
 };

--- a/apps/client/src/pages/community/community-edit/community-edit.tsx
+++ b/apps/client/src/pages/community/community-edit/community-edit.tsx
@@ -1,6 +1,10 @@
 import { ChangeEvent, useState } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from '@tanstack/react-query';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { Input, Navigation, TextButton, Title } from '@bds/ui';
 import { Icon } from '@bds/ui/icons';
@@ -11,7 +15,10 @@ import { categoryOptions } from '@widgets/community/configs/category-config';
 import { PLACEHOLDER } from '@widgets/community/constant/input-placeholder';
 import { CategoryType } from '@widgets/community/types/category-type';
 
-import { COMMUNITY_MUTATION_OPTIONS } from '@shared/api/domain/community/queries';
+import {
+  COMMUNITY_MUTATION_OPTIONS,
+  COMMUNITY_QUERY_OPTIONS,
+} from '@shared/api/domain/community/queries';
 import { COMMUNITY_QUERY_KEY } from '@shared/api/keys/query-key';
 import {
   LIMIT_LONG_TEXT,
@@ -26,29 +33,14 @@ const CommunityEdit = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { postId } = useParams<{ postId: string }>();
-  const location = useLocation();
-  const state = location.state as {
-    title: string;
-    content: string;
-    category?: { category: string; description: string };
-  };
-  const [title, setTitle] = useState(state.title);
-  const [content, setContent] = useState(state.content);
-
-  const getInitialCategory = () => {
-    return (
-      categoryOptions.find(
-        (option) => option.value === state.category?.category,
-      ) ?? null
-    );
-  };
-
-  const [category, setCategory] = useState(getInitialCategory);
-  const { isErrorState } = useLimitedInput(LIMIT_SHORT_TEXT, title.length);
 
   if (!postId) {
     throw new Error('게시글 Id가 존재하지 않습니다.');
   }
+
+  const { data: feedDetailData } = useSuspenseQuery(
+    COMMUNITY_QUERY_OPTIONS.FEED_DETAIL(postId),
+  );
 
   const { mutate, isPending } = useMutation({
     ...COMMUNITY_MUTATION_OPTIONS.PUT_FEED(postId),
@@ -60,28 +52,24 @@ const CommunityEdit = () => {
     },
   });
 
+  const [title, setTitle] = useState(feedDetailData?.title || '');
+  const [content, setContent] = useState(feedDetailData?.content || '');
+  const [category, setCategory] = useState(
+    feedDetailData?.category?.category || '',
+  );
+  const { isErrorState } = useLimitedInput(LIMIT_SHORT_TEXT, title.length);
+
   const handlePutFeed = () => {
-    if (isDisabled || !category) {
-      return;
-    }
-    //@TODO 타입 에러로 임시 작성해둠. 추후 구현 시 수정 필요
     mutate({
       body: {
         newTitle: title,
         newContent: content,
-        newCategory: category.value,
+        newCategory: category,
         deleteImageIds: [],
         updatedImages: [],
       },
     });
   };
-
-  const isDisabled =
-    !(
-      title.trim().length > 0 &&
-      content.trim().length > 0 &&
-      Boolean(category?.value)
-    ) || isPending;
 
   const handleGoBack = () => {
     navigate(-1);
@@ -100,7 +88,7 @@ const CommunityEdit = () => {
   };
 
   const handleCategory = (option: CategoryType) => {
-    setCategory(option);
+    setCategory(option.value);
   };
 
   return (
@@ -119,28 +107,35 @@ const CommunityEdit = () => {
           <TextButton
             size="sm"
             color="primary"
-            disabled={isDisabled}
+            disabled={
+              isPending || !title.trim() || !content.trim() || !category
+            }
             onClick={() => {
-              (handlePutFeed(), handleGoBack());
+              handlePutFeed();
+              handleGoBack();
             }}
           >
             완료
           </TextButton>
         }
-        isTextButton={true}
+        isTextButton
       />
       <div className={styles.postContainer}>
         <div className={styles.postHeader}>
           <div className={styles.postTitle}>
             <Title fontStyle="eb_md">제목</Title>
             <FilterDropDown
-              optionTitle={category ? category.label : '카테고리 선택'}
+              optionTitle={
+                categoryOptions.find((opt) => opt.value === category)?.label
+              }
+              rightIcon={<Icon name="caret_down_sm" />}
+              isIconRotate
             >
               {categoryOptions.map((option) => (
                 <TextButton
-                  key={option.value}
+                  key={option.label}
                   size="sm"
-                  color={category?.value === option.value ? 'primary' : 'black'}
+                  color={category === option.value ? 'primary' : 'black'}
                   onClick={() => handleCategory(option)}
                 >
                   {option.label}

--- a/apps/client/src/pages/community/community-edit/community-edit.tsx
+++ b/apps/client/src/pages/community/community-edit/community-edit.tsx
@@ -22,14 +22,6 @@ import { routePath } from '@shared/router/path';
 
 import * as styles from './community-edit.css';
 
-const COMMUNITY_CONTENT = {
-  TITLE: {
-    HEADER: '제목',
-    BODY: '내용',
-  },
-  BUTTON: '완료',
-};
-
 const CommunityEdit = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -132,7 +124,7 @@ const CommunityEdit = () => {
               (handlePutFeed(), handleGoBack());
             }}
           >
-            {COMMUNITY_CONTENT.BUTTON}
+            완료
           </TextButton>
         }
         isTextButton={true}
@@ -140,7 +132,7 @@ const CommunityEdit = () => {
       <div className={styles.postContainer}>
         <div className={styles.postHeader}>
           <div className={styles.postTitle}>
-            <Title fontStyle="eb_md">{COMMUNITY_CONTENT.TITLE.HEADER}</Title>
+            <Title fontStyle="eb_md">제목</Title>
             <FilterDropDown
               optionTitle={category ? category.label : '카테고리 선택'}
             >
@@ -165,7 +157,7 @@ const CommunityEdit = () => {
           />
         </div>
         <div className={styles.postContent}>
-          <Title fontStyle="eb_md">{COMMUNITY_CONTENT.TITLE.BODY}</Title>
+          <Title fontStyle="eb_md">내용</Title>
           <CommunityLine value={content} onChange={handleContentChange} />
         </div>
       </div>

--- a/apps/client/src/widgets/community/components/feed-content/feed-content.tsx
+++ b/apps/client/src/widgets/community/components/feed-content/feed-content.tsx
@@ -115,13 +115,7 @@ const FeedContent = ({ postId }: FeedContentProps) => {
   };
 
   const handleGoEdit = () => {
-    navigate(routePath.COMMUNITY_EDIT.replace(':postId', String(postId)), {
-      state: {
-        title: feedDetailData?.title,
-        content: feedDetailData?.content,
-        category: feedDetailData?.category,
-      },
-    });
+    navigate(routePath.COMMUNITY_EDIT.replace(':postId', String(postId)));
   };
 
   return (

--- a/apps/client/src/widgets/community/components/user-detail-meta/user-detail-meta.tsx
+++ b/apps/client/src/widgets/community/components/user-detail-meta/user-detail-meta.tsx
@@ -11,11 +11,6 @@ interface UserDetailMetaProps {
   onDeleteClick: () => void;
 }
 
-const BUTTON_TEXT = {
-  EDIT: '수정',
-  DELETE: '삭제',
-};
-
 const UserDetailMeta = ({
   nickName,
   createdAt,
@@ -41,7 +36,7 @@ const UserDetailMeta = ({
             style={{ padding: '0.6rem 0.8rem' }}
             onClick={onEditClick}
           >
-            {BUTTON_TEXT.EDIT}
+            수정
           </TextButton>
           <TextButton
             size="sm"
@@ -49,7 +44,7 @@ const UserDetailMeta = ({
             style={{ padding: '0.6rem 0.8rem' }}
             onClick={onDeleteClick}
           >
-            {BUTTON_TEXT.DELETE}
+            삭제
           </TextButton>
         </div>
       ) : (

--- a/apps/client/src/widgets/community/utils/type-guard.ts
+++ b/apps/client/src/widgets/community/utils/type-guard.ts
@@ -1,0 +1,24 @@
+import { components } from '@shared/types/schema';
+
+/**
+ * 이미지 객체의 유효성을 검사하는 타입 가드 함수입니다.
+ *
+ * API 스키마에서 `imageId`와 `imageUrl`은 `undefined`일 수 있도록 정의되어 있습니다.
+ * 이로 인해 실제로 이미지가 존재하지 않는 경우에도 `|| []` 같은 불필요한 방어 로직이 들어가거나,
+ * 이미지가 존재하지 않아야 할 상황에서 잘못된 값이 렌더링되는 문제가 발생했습니다.
+ *
+ * 이 타입 가드는 `imageId`와 `imageUrl`이 모두 올바르게 존재하는 경우만을 통과시켜,
+ * `undefined` 가능성을 제거하고 코드 전반에서 보다 명확하고 안전하게 이미지 데이터를 다룰 수 있도록 합니다.
+ *
+ * @param image - 검사할 이미지 객체
+ * @returns `image`가 유효한 이미지(`imageId`와 `imageUrl`을 모두 가진 경우)라면 `true`
+ */
+export function isValidImage(
+  image: components['schemas']['PostDetailImageResponse'],
+): image is { imageId: number; imageUrl: string } {
+  return (
+    typeof image.imageId === 'number' &&
+    typeof image.imageUrl === 'string' &&
+    image.imageUrl.trim().length > 0
+  );
+}


### PR DESCRIPTION
## 📌 Summary

- #463 

## 📚 Tasks

- 글 수정 시 필터드롭다운 UI 수정
- 글 수정 시 이미지 업로드 반영

## 👀 To Reviewer

일단 게시물 수정 api 가 좀 복잡해요, updatedImages 랑 deletedImages 를 구분해서 body에 담아야하고, 자세한건 [슬랙](https://bofit.slack.com/archives/C09EBL5MR5X/p1760022970695639)을 읽어보시면 좋을 것 같아요.  

주요 수정 내용은 기존에는 

```typescript
  const state = location.state as {
    title: string;
    content: string;
    category?: { category: string; description: string };
  };
```

이런식으로 게시글 데이터를 location.state 로 전달받아 사용하고 있었는데, 이 방법은 데이터 조회 목적의 api 설계 의도와 맞지 않는다고 생각했어요. state 는 네비게이션 상태 전달용으로만 사용되어야 하고, 실제 게시글 데이터는 서버의 단일 진실원인 조회 api 를 통해 가져오는 것이 적절한 것 같아요. 라우터 state 는 페이지 스크롤 위치, 직전 필터 옵션 등등으로만 사용하도록 해요

항상 서버 기준으로 `수정 가능한 게시글인지` 등을 판단하는 것이 도메인 무결성을 지키는 개발이라고 생각해요. 

### 타입 가드

isVaildImage 타입 가드는 API 스키마에서 imageId와 imageUrl이 undefined 가능하도록 정의되어 있는 문제를 해결하기 위해 만들었어요. 기존에는 || [] 와 같은 방어로직을 곳곳에 추가하거나 했어야했는데, 애초에 이미지가 존재하지 않는다면 imageContainer 자체가 dom 에 존재하면 안되는 것 같아요

그리고 요구사항 자체가 "이미지가 있을 때만 이미지가 보여집니다" 라는 뜻은 undefined 가능성이 코드레벨에서도 0에 수렴해야한다고 생각해요. 이미지가 있을 때만 렌더링하도록 한다. 라는 의미가 코드에서도 잘 드러나려면 옵셔널 체이닝을 사용하면 안되기에. isVaildImage 를 통해서 id와 url이 모두 유효한 경우만 필터링하도록 하고, 존재하는 이미지가 있을 때만 렌더링 하도록 처리해두었어요.

| 이미지가 없을 경우 dom에 존재하지 않음 | 이미지가 존재할 때에만 dom에 존재함 |
|-------------|-------------|
| <img width="180" alt="이미지가 없을 경우 dom에 존재하지 않음" src="https://github.com/user-attachments/assets/bb2b6ea0-9c77-4b41-b35b-11e6b01750c7" /> | <img width="180" alt="이미지가 존재할 때에만 dom에 존재함" src="https://github.com/user-attachments/assets/1820858e-6bfe-4a6b-9c09-fa4c58d2f4c6" /> |




## 🕶️ Requirements Checklist
- [x] 기존 이미지 삭제
- [x] 새로운 이미지 삭제
- [x] 기존 이미지 재 업로드
- [x] 새로운 이미지 업로드
- [x] 기존 이미지 + 새로운 이미지 업로드
- [x] 이미지 0개 업로드
- [x] 이미지 + 제목 + 컨텐츠 수정




## 📸 Screenshot



https://github.com/user-attachments/assets/d9686d09-66df-4a72-83f5-70c8161d25c7

