### PR TITLE
Fix(bds): 캐러셀 컴포넌트 IOS, And 대응

### DIFF
--- a/apps/client/src/pages/home/home-page.tsx
+++ b/apps/client/src/pages/home/home-page.tsx
@@ -43,7 +43,7 @@ const HomePage = () => {
       />
       {userData?.isRecommendInsurance ? (
         <>
-          <RecommendedInfoSection userName={'김민정'} />
+          <RecommendedInfoSection userName={userData?.username} />
           <FeaturesSection height={'md'} />
         </>
       ) : (

--- a/apps/client/src/pages/home/home-page.tsx
+++ b/apps/client/src/pages/home/home-page.tsx
@@ -43,7 +43,7 @@ const HomePage = () => {
       />
       {userData?.isRecommendInsurance ? (
         <>
-          <RecommendedInfoSection userName={userData?.username} />
+          <RecommendedInfoSection userName={'김민정'} />
           <FeaturesSection height={'md'} />
         </>
       ) : (

--- a/apps/client/src/widgets/home/components/info-section/info-section.tsx
+++ b/apps/client/src/widgets/home/components/info-section/info-section.tsx
@@ -34,7 +34,7 @@ export const InfoSection = () => {
       </div>
       <Carousel slidesPerView={4.5} autoPlay className={styles.homeCardList}>
         {homeCardConfig.map((card, index) => (
-          <Carousel.Item key={index} style={{ width: 'auto' }}>
+          <Carousel.Item key={index}>
             <HomeCard
               icon={
                 <img

--- a/packages/bds-ui/src/components/carousel/carousel.css.ts
+++ b/packages/bds-ui/src/components/carousel/carousel.css.ts
@@ -9,6 +9,8 @@ export const container = style({
   height: '100%',
   overflowX: 'scroll',
   userSelect: 'none',
+  WebkitOverflowScrolling: 'touch',
+  touchAction: 'pan-x',
 });
 
 export const slideContainer = style({
@@ -20,6 +22,7 @@ export const slideContainer = style({
   gap: '1rem',
   userSelect: 'none',
   WebkitUserSelect: 'none',
+  touchAction: 'pan-x',
 });
 
 export const slide = style({

--- a/packages/bds-ui/src/components/carousel/carousel.tsx
+++ b/packages/bds-ui/src/components/carousel/carousel.tsx
@@ -134,7 +134,7 @@ const Carousel = ({
       if (autoSlideWidth > 0 && containerWidth > 0) {
         const config: CarouselControllerConfig = {
           totalItems,
-          slidesPerView: 1, // 항상 1개씩 이동
+          slidesPerView: 1,
           slideWidth: (autoSlideWidth / containerWidth) * 100,
           infinite: effectiveInfinite,
         };
@@ -370,8 +370,10 @@ const Carousel = ({
             transform: getTransform(),
             transition: isDragging
               ? 'none'
-              : 'transform 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94)',
-            cursor: isDragging ? 'grabbing' : 'pointer',
+              : autoPlay
+                ? 'none'
+                : 'transform 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94)',
+            cursor: isDragging ? 'grabbing' : 'grab',
             height: maxSlideHeight ? `${maxSlideHeight}px` : 'auto',
             width: isAutoMode ? 'max-content' : '100%',
           }}
@@ -380,13 +382,21 @@ const Carousel = ({
             const itemProps = (
               slide.data as React.ReactElement<CarouselItemProps>
             ).props;
-            const { children, className, ...restProps } = itemProps;
+            const {
+              children,
+              className,
+              style: itemStyle,
+              ...restProps
+            } = itemProps;
 
             return (
               <div
                 key={slide.key}
                 className={`${styles.slide} ${className || ''}`}
-                style={slide.style}
+                style={{
+                  ...slide.style,
+                  ...itemStyle,
+                }}
                 {...restProps}
               >
                 {children}

--- a/packages/bds-ui/src/components/carousel/carousel.tsx
+++ b/packages/bds-ui/src/components/carousel/carousel.tsx
@@ -382,21 +382,13 @@ const Carousel = ({
             const itemProps = (
               slide.data as React.ReactElement<CarouselItemProps>
             ).props;
-            const {
-              children,
-              className,
-              style: itemStyle,
-              ...restProps
-            } = itemProps;
+            const { children, className, ...restProps } = itemProps;
 
             return (
               <div
                 key={slide.key}
                 className={`${styles.slide} ${className || ''}`}
-                style={{
-                  ...slide.style,
-                  ...itemStyle,
-                }}
+                style={slide.style}
                 {...restProps}
               >
                 {children}

--- a/packages/bds-ui/src/components/carousel/hooks/use-carousel-touch.ts
+++ b/packages/bds-ui/src/components/carousel/hooks/use-carousel-touch.ts
@@ -86,7 +86,6 @@ export const useCarouselTouch = ({
       const containerWidth = e.currentTarget.clientWidth || 1;
       const dragOffsetPercent = (diff / containerWidth) * 100;
 
-      // autoPlay 모드에서는 드래그만 처리
       if (autoPlay) {
         const newState = controller.handleDragEnd(
           carouselState,
@@ -98,7 +97,6 @@ export const useCarouselTouch = ({
 
         onStateUpdate(newState);
       } else {
-        // 수동 모드에서는 드래그 vs 클릭 구분
         if (hasMoved) {
           const newState = controller.handleDragEnd(
             carouselState,

--- a/packages/bds-ui/src/components/carousel/hooks/use-carousel-touch.ts
+++ b/packages/bds-ui/src/components/carousel/hooks/use-carousel-touch.ts
@@ -53,7 +53,6 @@ export const useCarouselTouch = ({
         return;
       }
 
-      // iOS Safari에서 스크롤 방지
       if (e.pointerType === 'touch') {
         e.preventDefault();
       }
@@ -74,7 +73,7 @@ export const useCarouselTouch = ({
 
   /** 뗄 때 드래그 거리 기준으로 컨트롤러를 통해 새로운 상태 계산
    * - autoPlay=false: 드래그 여부에 따라 슬라이드 변경 or 클릭 이벤트 처리
-   * - autoPlay=true: 항상 드래그로 처리 (onClick 무시)
+   * - autoPlay=true: 드래그 후 RAF 재개를 위해 상태 업데이트
    */
 
   const handlePointerUp = useCallback(
@@ -83,12 +82,24 @@ export const useCarouselTouch = ({
         return;
       }
 
-      if (!autoPlay) {
-        if (hasMoved) {
-          const diff = startX - e.clientX;
-          const containerWidth = e.currentTarget.clientWidth || 1;
-          const dragOffsetPercent = (diff / containerWidth) * 100;
+      const diff = startX - e.clientX;
+      const containerWidth = e.currentTarget.clientWidth || 1;
+      const dragOffsetPercent = (diff / containerWidth) * 100;
 
+      // autoPlay 모드에서는 드래그만 처리
+      if (autoPlay) {
+        const newState = controller.handleDragEnd(
+          carouselState,
+          dragOffsetPercent,
+          {
+            isAutoPlay: true,
+          },
+        );
+
+        onStateUpdate(newState);
+      } else {
+        // 수동 모드에서는 드래그 vs 클릭 구분
+        if (hasMoved) {
           const newState = controller.handleDragEnd(
             carouselState,
             dragOffsetPercent,
@@ -103,20 +114,6 @@ export const useCarouselTouch = ({
             clickTarget.click();
           }
         }
-      } else {
-        const diff = startX - e.clientX;
-        const containerWidth = e.currentTarget.clientWidth || 1;
-        const dragOffsetPercent = (diff / containerWidth) * 100;
-
-        const newState = controller.handleDragEnd(
-          carouselState,
-          dragOffsetPercent,
-          {
-            isAutoPlay: true,
-          },
-        );
-
-        onStateUpdate(newState);
       }
 
       setIsDragging(false);

--- a/packages/bds-ui/src/components/carousel/hooks/use-carousel-touch.ts
+++ b/packages/bds-ui/src/components/carousel/hooks/use-carousel-touch.ts
@@ -28,6 +28,10 @@ export const useCarouselTouch = ({
   /** 누를 때 시작 위치 저장 */
   const handlePointerDown = useCallback(
     (e: PointerEvent<Element>) => {
+      if (e.pointerType === 'touch') {
+        e.preventDefault();
+      }
+
       setIsDragging(true);
       setStartX(e.clientX);
       setDragOffset(0);
@@ -47,6 +51,11 @@ export const useCarouselTouch = ({
     (e: PointerEvent<Element>) => {
       if (!isDragging) {
         return;
+      }
+
+      // iOS Safari에서 스크롤 방지
+      if (e.pointerType === 'touch') {
+        e.preventDefault();
       }
 
       const dragDiff = startX - e.clientX;

--- a/packages/bds-ui/src/components/carousel/hooks/use-carousel-touch.ts
+++ b/packages/bds-ui/src/components/carousel/hooks/use-carousel-touch.ts
@@ -73,7 +73,7 @@ export const useCarouselTouch = ({
 
   /** 뗄 때 드래그 거리 기준으로 컨트롤러를 통해 새로운 상태 계산
    * - autoPlay=false: 드래그 여부에 따라 슬라이드 변경 or 클릭 이벤트 처리
-   * - autoPlay=true: 드래그 후 RAF 재개를 위해 상태 업데이트
+   * - autoPlay=true: 항상 드래그로 처리 (onClick 무시)
    */
 
   const handlePointerUp = useCallback(


### PR DESCRIPTION
## 📌 Summary

> - close #476

- 모바일 스크롤 문제 해결
- autoPlay true 일 때 요소 사라지는 버그 대응

## 📚 Tasks


### 슬라이드 안되는 문제

영상 보시면, 모바일 환경에서 슬라이드 할 때 아예 옆으로 안 움직이는 문제가 있었습니다. 

**[ IOS AS-IS ]**

https://github.com/user-attachments/assets/7aec9a6e-f553-4f53-98e4-4dfbd69c1985


해당 문제를 다음과 같이 해결했습니다. 

```ts
WebkitOverflowScrolling: 'touch',
touchAction: 'pan-x',
```

- `WebkitOverflowScrolling : 'touch'` 는  은 스크롤 화면의 '터치' 반응에 대해 더 자연스럽고 매끄럽게 빠른 반응을 활성화 합니다. 
-` touchAction: 'pan-x',` 는 스크롤을 가로 방향만 터치 허용하도록 합니다.

이 두 속성을 캐러셀 컨테이너에 추가하고, 
캐러셀 controller 중 handlePointerDown 과 handlePointerMove 에 해당 코드를 추가했습니다.

```ts
if (e.pointerType === 'touch') {
        e.preventDefault();
}
```
-> 터치 이벤트의 기본 동작(스크롤, 줌, 스와이프) 를 차단하고 터치 입력을 독점적으로 처리합니다.


> preventDefault() 없으면
> 터치 시작 시 브라우저: "스크롤인가?"
>  -> RAF는 계속 실행 중
>  -> offsetRef와 dragOffset 불일치
>  -> 가상화 오류

> preventDefault() 있으면
>  터치 시작 시 즉시 드래그로 인식
>   -> isDragging=true → RAF 즉시 중단
>   -> dragOffset만 업데이트
>   -> 가상화 정상 작동

따라서 터치 이벤트가 발생하면(모바일) preventDefault 를 하도록 수정했습니다.
결과적으로 드래그 tobe 영상입니다

<br />


**[ Android TO-BE ]**

https://github.com/user-attachments/assets/7a1bd296-489a-4f62-b020-6beb860defa3

**[ IOS TO-BE ]**

https://github.com/user-attachments/assets/57ce1535-bb4e-4256-a983-f3b7d6548ab8



<br />



### autoPlay ture 일 때 지진나는 문제


<img width="1113" height="191" alt="스크린샷 2025-10-26 02 45 22" src="https://github.com/user-attachments/assets/5ed7f9da-c1d0-450a-8e3f-0e06f323e53d" />

이 코드 보시면, 원래는 autoPlay 일 때도 transition 이 있었습니다. 

requestAnimationFrame 는 16ms 마다 계속 실행되는데, CSS transition 은 천천히 이동중이어서 (거의 안 움직이는)
두 이동 시간의 타이밍 차이가 문제였던 것 같아요. 

정확히 설명하자면, 

#### Frame 2 (16ms) 


`offsetRef.current = 10.5%`
`setCarouselState({ offset: 10.5% })`


 화면 렌더링
```ts
 <div style={{
   transform: 'translateX(-10.5%)',
   transition: 'transform 0.5s ...'
 }}>
```

브라우저는 
1. transform 이 -10.0% 에서 -10.5% 로 바뀌었네!
2. transition 이 0.5s 이니까 500ms 동안 이동시켜야지
3. CSS transition 시작 ( -10.0% 에서 500ms초 동안 ->  -10.5% )


#### Frame 3 (32ms) 
`offsetRef.current = 11.0%`
`setCarouselState({ offset: 11.0% })`

문제는 32ms 밖에 안 됐기 때문에 CSS transition 은 -10.016% 이정도 밖에 못 간 상태에서 
다음 Frame 이 실행되는 바람에 
새롭게 RAF 명령은 11.0% 로 가라는 명령을 받게 되면서
화면에서는
- -10.016% 위치에 있다가
- 갑자기 -11.0% 을 향해 이동
- 0.987% 를 500ms 걸쳐 이동하려고 함 -> 너무 느리게 됨.

그래서 즉 RAF 는 빠르게 증가시키는데, CSS transtion 이 천천히 따라가려고 하는 문제 때문에 슬라이드가 덜덜덜 떨리는 현상이 생겼던 것 같습니다. 


✅ 해결

autoPlay일 때 transition: 'none' 을 적용해서 RAF 와 transition 이 충돌하지 않도록 설정했어요. 
그랬더니 안드 아이오 모두 잘 작동하는 것을 확인할 수 있었습니다.



**[ IOS AS-IS ]**

https://github.com/user-attachments/assets/41b7320c-6114-44d3-b4a0-a41cbc88cc65

**[ IOS TO-BE ]**

https://github.com/user-attachments/assets/a516b19e-8d47-4407-99c7-9b4b7540113e



