### PR TITLE
Fix(client): 대댓글 작성시 backdrop 클릭 시 작성 모드 해제되도록 수정

### DIFF
--- a/apps/client/src/widgets/community/components/comment-input-box/comment-input-box.tsx
+++ b/apps/client/src/widgets/community/components/comment-input-box/comment-input-box.tsx
@@ -6,6 +6,8 @@ import { Icon } from '@bds/ui/icons';
 import { PLACEHOLDER } from '@widgets/community/constant/input-placeholder';
 import { useChangeInputMode } from '@widgets/community/context/input-mode-context';
 
+import useClickOutside from '@shared/hooks/use-click-outside';
+
 import CommunityModal from '../community-modal/community-modal';
 
 import * as styles from './comment-input-box.css';
@@ -34,8 +36,16 @@ const CommentInputBox = ({
   onClearImage,
 }: CommentInputBoxProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const wrapperRef = useRef<HTMLElement>(null);
   const { mode, dispatch } = useChangeInputMode();
   const { openModal, closeModal } = useModal();
+
+  const replyCreateMode = mode.type === 'reply' && mode.action === 'create';
+  useClickOutside(
+    wrapperRef,
+    () => dispatch({ type: 'RESET' }),
+    replyCreateMode,
+  );
 
   const modalType: 'create' | 'edit' =
     (mode.type === 'comment' || mode.type === 'reply') && mode.action === 'edit'
@@ -105,7 +115,7 @@ const CommentInputBox = ({
     : previewUrl;
 
   return (
-    <section className={styles.commentWrapper}>
+    <section ref={wrapperRef} className={styles.commentWrapper}>
       {displayImage && (
         <div className={styles.imagePreviewWrapper}>
           <img

--- a/apps/client/src/widgets/community/components/detail-section/detail-section.tsx
+++ b/apps/client/src/widgets/community/components/detail-section/detail-section.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import CommentInputBox from '@widgets/community/components/comment-input-box/comment-input-box';
@@ -26,10 +26,14 @@ const DetailSection = ({ postId }: DetailSectionProps) => {
 
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const prevModeRef = useRef(mode);
 
   const queryClient = useQueryClient();
 
   useEffect(() => {
+    const prevMode = prevModeRef.current;
+    prevModeRef.current = mode;
+
     if (mode.type === 'comment' && mode.action === 'edit') {
       const remaining = (mode.images ?? []).filter(
         (img) => !(mode.deleteImageIds ?? []).includes(img.imageId ?? -1),
@@ -62,6 +66,15 @@ const DetailSection = ({ postId }: DetailSectionProps) => {
 
       setImagePreview(remaining[0]?.imageUrl ?? null);
       setImageFile(null);
+      return;
+    }
+
+    if (
+      prevMode.type === 'reply' &&
+      prevMode.action === 'create' &&
+      mode.type === 'comment' &&
+      mode.action === 'create'
+    ) {
       return;
     }
 

--- a/apps/client/src/widgets/community/components/detail-section/detail-section.tsx
+++ b/apps/client/src/widgets/community/components/detail-section/detail-section.tsx
@@ -31,7 +31,11 @@ const DetailSection = ({ postId }: DetailSectionProps) => {
   const queryClient = useQueryClient();
 
   useEffect(() => {
-    const prevMode = prevModeRef.current;
+    const isStillCreatingMode =
+      prevModeRef.current.action === 'create' && mode.action === 'create';
+    const typeChanged = prevModeRef.current.type !== mode.type;
+    const shouldPreserveContent = isStillCreatingMode && typeChanged;
+
     prevModeRef.current = mode;
 
     if (mode.type === 'comment' && mode.action === 'edit') {
@@ -69,11 +73,7 @@ const DetailSection = ({ postId }: DetailSectionProps) => {
       return;
     }
 
-    const isStillCreatingMode =
-      prevMode.action === 'create' && mode.action === 'create';
-    const typeChanged = prevMode.type !== mode.type;
-
-    if (isStillCreatingMode && typeChanged) {
+    if (shouldPreserveContent) {
       return;
     }
 

--- a/apps/client/src/widgets/community/components/detail-section/detail-section.tsx
+++ b/apps/client/src/widgets/community/components/detail-section/detail-section.tsx
@@ -69,12 +69,11 @@ const DetailSection = ({ postId }: DetailSectionProps) => {
       return;
     }
 
-    if (
-      prevMode.type === 'reply' &&
-      prevMode.action === 'create' &&
-      mode.type === 'comment' &&
-      mode.action === 'create'
-    ) {
+    const isStillCreatingMode =
+      prevMode.action === 'create' && mode.action === 'create';
+    const typeChanged = prevMode.type !== mode.type;
+
+    if (isStillCreatingMode && typeChanged) {
       return;
     }
 

--- a/apps/client/src/widgets/community/components/detail-section/detail-section.tsx
+++ b/apps/client/src/widgets/community/components/detail-section/detail-section.tsx
@@ -34,7 +34,6 @@ const DetailSection = ({ postId }: DetailSectionProps) => {
     const isStillCreatingMode =
       prevModeRef.current.action === 'create' && mode.action === 'create';
     const typeChanged = prevModeRef.current.type !== mode.type;
-    const shouldPreserveContent = isStillCreatingMode && typeChanged;
 
     prevModeRef.current = mode;
 
@@ -73,7 +72,7 @@ const DetailSection = ({ postId }: DetailSectionProps) => {
       return;
     }
 
-    if (shouldPreserveContent) {
+    if (isStillCreatingMode && typeChanged) {
       return;
     }
 

--- a/apps/client/src/widgets/community/hooks/use-controll-input-box.ts
+++ b/apps/client/src/widgets/community/hooks/use-controll-input-box.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { InputBoxMode } from '@widgets/community/types/input-box-type';
 
@@ -8,8 +8,21 @@ export const useControlledInputBox = (mode: InputBoxMode) => {
   const [content, setContent] = useState(
     'initialContent' in mode ? mode.initialContent : '',
   );
+  const prevModeRef = useRef(mode);
 
   useEffect(() => {
+    const prevMode = prevModeRef.current;
+    prevModeRef.current = mode;
+
+    if (
+      prevMode.type === 'reply' &&
+      prevMode.action === 'create' &&
+      mode.type === 'comment' &&
+      mode.action === 'create'
+    ) {
+      return;
+    }
+
     setContent('initialContent' in mode ? mode.initialContent : '');
   }, [mode]);
 

--- a/apps/client/src/widgets/community/hooks/use-controll-input-box.ts
+++ b/apps/client/src/widgets/community/hooks/use-controll-input-box.ts
@@ -11,12 +11,11 @@ export const useControlledInputBox = (mode: InputBoxMode) => {
   const prevModeRef = useRef(mode);
 
   useEffect(() => {
-    const prevMode = prevModeRef.current;
-    prevModeRef.current = mode;
-
     const isStillCreatingMode =
-      prevMode.action === 'create' && mode.action === 'create';
-    const typeChanged = prevMode.type !== mode.type;
+      prevModeRef.current.action === 'create' && mode.action === 'create';
+    const typeChanged = prevModeRef.current.type !== mode.type;
+
+    prevModeRef.current = mode;
 
     if (isStillCreatingMode && typeChanged) {
       return;

--- a/apps/client/src/widgets/community/hooks/use-controll-input-box.ts
+++ b/apps/client/src/widgets/community/hooks/use-controll-input-box.ts
@@ -14,12 +14,11 @@ export const useControlledInputBox = (mode: InputBoxMode) => {
     const prevMode = prevModeRef.current;
     prevModeRef.current = mode;
 
-    if (
-      prevMode.type === 'reply' &&
-      prevMode.action === 'create' &&
-      mode.type === 'comment' &&
-      mode.action === 'create'
-    ) {
+    const isStillCreatingMode =
+      prevMode.action === 'create' && mode.action === 'create';
+    const typeChanged = prevMode.type !== mode.type;
+
+    if (isStillCreatingMode && typeChanged) {
       return;
     }
 


### PR DESCRIPTION
## 📌 Summary

> - #485 

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._
- inputBox에 백드롭 추가
- 대댓글 상태일때 백드롭시 댓글 상태로 전환
- 위와 같이 전환할 때 댓글, 대댓글때의 이미지 유지
## 📚 Tasks
커뮤니티 상세 페이지에서 대댓글을 작성할 때 밖을 클릭해도 대댓글 작성 모드가 풀리지 않는 이슈가 있었어요.

이를 해결하기 위해 `수정`님이 만드신 `useClickOutside` 훅을 활용했어요.
`CommentInputBox` 컴포넌트에서 `useClickOutside` 훅을 사용하여 대댓글 작성 모드(replyCreateMode)일 때만 외부 클릭 감지를 활성화하고, 외부 클릭 시 `RESET` 액션을 통해 댓글 작성 모드로 전환되도록 수정했어요.

추가로 모드 전환 시 사용자가 작성 중이던 내용이 날아가는 문제가 있어서 inputBox 텍스트와 이미지가 유지되도록 처리했습니다.

<!--
## 👀 To Reviewer

(기재 내용 없을 경우 섹션 삭제) 더 전달할 내용 혹은 리뷰에게 요청하는 내용을 작성해주세요.
-->

<!--
## 🕶️ Requirements Checklist
- [ ]

(기능 명세서상 내용을 복사해서 테스트해주세요)
-->

## 📸 Screenshot

https://github.com/user-attachments/assets/1be87f9b-d3d1-4af1-9534-76aab03e31b2
