### PR TITLE
Fix(client): 필터 드롭다운 컴포넌트 수정

### DIFF
--- a/apps/client/src/widgets/community/components/filter-dropdown/filter-dropdown.css.ts
+++ b/apps/client/src/widgets/community/components/filter-dropdown/filter-dropdown.css.ts
@@ -63,6 +63,12 @@ export const DropDownContent = style({
   zIndex: themeVars.zIndex.content,
 });
 
+export const DropDownItem = style({
+  padding: '0.6rem 0',
+  ...themeVars.fontStyles.title_sb_16,
+  color: themeVars.color.gray800,
+});
+
 export const isRotate = recipe({
   base: {
     transform: 'rotate(0deg)',

--- a/apps/client/src/widgets/community/components/filter-dropdown/filter-dropdown.tsx
+++ b/apps/client/src/widgets/community/components/filter-dropdown/filter-dropdown.tsx
@@ -37,7 +37,9 @@ const FilterDropDown = ({
       {open && (
         <div className={styles.DropDownContent}>
           {Children.map(children, (child, idx) => (
-            <div key={idx}>{child}</div>
+            <div key={idx} className={styles.DropDownItem}>
+              {child}
+            </div>
           ))}
         </div>
       )}


### PR DESCRIPTION
## 📌 Summary

> - #487 

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

- 필터 드롭다운 컴포넌트 사이즈 이슈 해결

## 📚 Tasks
기존 필터 드롭다운 컴포넌트의 사이즈가 맞지 않다고 해서 확인해보니 드롭다운 안의 개별 아이템들에 패딩값이 적용되어있지 않았어요.
그래서 개별 아이템들에 padding값을 추가하고, fontStyle과 color도 같이 적용시켰습니다.

<!--
## 👀 To Reviewer

(기재 내용 없을 경우 섹션 삭제) 더 전달할 내용 혹은 리뷰에게 요청하는 내용을 작성해주세요.
-->

<!--
## 🕶️ Requirements Checklist
- [ ]

(기능 명세서상 내용을 복사해서 테스트해주세요)
-->


## 📸 Screenshot
## [AS-IS]
<img width="370" height="662" alt="image" src="https://github.com/user-attachments/assets/92d5290d-a8f5-4791-a134-5c5de1230cc4" />

## [TO-BE]
<img width="369" height="663" alt="image" src="https://github.com/user-attachments/assets/3666d166-77d9-4384-979f-e532bb21328b" />
