### PR TITLE
Fix(bds): Alert 컴포넌트 문구 색상 변경

### DIFF
--- a/packages/bds-ui/src/components/alert/alert.css.ts
+++ b/packages/bds-ui/src/components/alert/alert.css.ts
@@ -44,11 +44,22 @@ export const alerIconContainer = recipe({
   },
 });
 
-export const alertHeader = style({
-  ...themeVars.fontStyles.head2_b_14,
-  color: themeVars.color.error,
-  display: 'flex',
-  alignItems: 'center',
+export const alertHeader = recipe({
+  base: {
+    ...themeVars.fontStyles.head2_b_14,
+    display: 'flex',
+    alignItems: 'center',
+  },
+  variants: {
+    type: {
+      info: {
+        color: themeVars.color.error,
+      },
+      additional: {
+        color: themeVars.color.primary500,
+      },
+    },
+  },
 });
 
 export const alertContentsHighlight = style({

--- a/packages/bds-ui/src/components/alert/alert.tsx
+++ b/packages/bds-ui/src/components/alert/alert.tsx
@@ -10,15 +10,17 @@ interface AlertProps {
   type: 'additional' | 'info';
   highlight?: string;
 }
+
 /**
  * Alert 컴포넌트는 알림 메시지를 표시하는 컴포넌트입니다.
  * @param iconName - Icon name
  * @param iconSize - Icon height과 width
  * @param alertHeader - alert에 들어갈 헤더 (참고하세요!, 알려드려요)
  * @param alertContents -alert에 들어갈 contents
+ * @param type - alert의 타입 (additional, info)
+ * @param highlight - alertContents에서 강조할 단어 (type이 additional일 때만 사용)
  * @returns
  */
-
 const Alert = ({
   iconName,
   iconSize,
@@ -37,7 +39,7 @@ const Alert = ({
           height={iconSize}
           className={styles.iconStyle}
         />
-        <p className={styles.alertHeader}>{alertHeader}</p>
+        <p className={styles.alertHeader({ type })}>{alertHeader}</p>
       </div>
       <p className={styles.alertContents({ type })}>
         {type === 'additional' && (

--- a/packages/bds-ui/src/components/alert/alert.tsx
+++ b/packages/bds-ui/src/components/alert/alert.tsx
@@ -2,12 +2,15 @@ import { Icon } from '@bds/ui/icons';
 
 import * as styles from './alert.css';
 
+type IconNameType = 'info' | 'info_warning';
+type AlertType = 'additional' | 'info';
+
 interface AlertProps {
-  iconName: 'info' | 'info_warning';
+  iconName: IconNameType;
   iconSize: string;
   alertHeader: string;
   alertContents: string;
-  type: 'additional' | 'info';
+  type: AlertType;
   highlight?: string;
 }
 


### PR DESCRIPTION
## 📌 Summary

> - #484 

Alert 컴포넌트 문구 색상 변경을 진행합니다.

## 📚 Tasks

- alertHeader 색상을 type에 따른 분기로 색상 변경
- type 정의 개선

Alert 컴포넌트를 info와 additional 두 가지 타입으로 구분해 사용하고 있어요.
info는 커뮤니티 페이지의 “알려드려요” 영역에서 사용하고 있고,
additional은 보험 추천 페이지의 “참고하세요” 영역에서 사용하고 있어요.

제가 스프린트 때 Alert 컴포넌트를 수정하는 과정에서 icon 색상은 type에 따라 정상적으로 분기하도록 했지만 alertHeader 색상은 분기 처리를 하지 않아서 additional 타입에서도 primary500이 아닌 error 계열 색상으로 표시되는 문제가 있었던 것 같습니다...

따라서 alertHeader 색상 역시 type에 맞게 분기되도록 수정하여 additional 타입일 때 올바른 스타일이 적용되도록 반영했습니당


## 👀 To Reviewer

화이팅..

<!--
## 🕶️ Requirements Checklist
- [ ]

(기능 명세서상 내용을 복사해서 테스트해주세요)
-->

## 📸 Screenshot

before
<img width="421" height="173" alt="image" src="https://github.com/user-attachments/assets/c1d57f1c-f8c3-45a3-916f-92fc49a944ac" />

after
<img width="425" height="174" alt="image" src="https://github.com/user-attachments/assets/acdf9374-5951-442e-af08-3dcb9a9d87a1" />

