### PR TITLE
Fix(client): 댓글, 대댓글 작성 중 취소 시 취소 상태 유지 모달 관련 문구 수정

### DIFF
--- a/apps/client/src/widgets/community/constant/modal-content.ts
+++ b/apps/client/src/widgets/community/constant/modal-content.ts
@@ -24,13 +24,13 @@ export const COMMENT_MODAL: Record<
   CREATE: {
     TITLE: '작성 내용을 삭제할까요?',
     CONTENT: '내용이 저장되지 않습니다.',
-    CANCEL: '계속 작성하기',
+    CANCEL: '취소',
     CONFIRM: '삭제',
   },
   EDIT: {
     TITLE: '수정 내용을 삭제할까요?',
     CONTENT: '내용이 저장되지 않습니다.',
-    CANCEL: '계속 수정하기',
+    CANCEL: '취소',
     CONFIRM: '삭제',
   },
 };


### PR DESCRIPTION
## 📌 Summary

> - #490 

- 댓글, 대댓글 작성 중 취소 시 취소 상태 유지 모달 관련 문구 수정

## 📚 Tasks
기존에 댓글을 작성하거나 수정 중에 `취소` 버튼을 눌러 나오는 모달의 `계속 작성하기` `계속 수정하기` 문구가 사이즈를 초과하여 2줄로 표기되는 이슈가 있었어요. 피그마에서 확인하니 디자인에서 양 옆 패딩은 2rem으로 되어 있는데 내용이 밖으로 튀어나와 있던걸 발견습니다.

이에 디자인과의 대화 끝에 `계속 작성하기`, `계속 수정하기` 문구를 `취소`로 변경하기로 했어요.

<!--
## 👀 To Reviewer

(기재 내용 없을 경우 섹션 삭제) 더 전달할 내용 혹은 리뷰에게 요청하는 내용을 작성해주세요.
-->

<!--
## 🕶️ Requirements Checklist
- [ ]

(기능 명세서상 내용을 복사해서 테스트해주세요)
-->

## 📸 Screenshot
## [AS-IS]
<img width="200" height="500" alt="image" src="https://github.com/user-attachments/assets/c4764d07-5d2e-4dbe-abaf-6b6b2bf8d3fa" />
<img width="400" height="150" alt="image" src="https://github.com/user-attachments/assets/5708e257-b7f2-4b6d-bac5-3aa6bc280af2" />
<img width="400" height="150" alt="image" src="https://github.com/user-attachments/assets/3349476f-5951-48d5-b465-823600efb091" />


## [TO-BE]
<img width="400" height="250" alt="image" src="https://github.com/user-attachments/assets/2c311825-389f-4e82-9757-214a839ddc43" />

<img width="350" height="250" alt="image" src="https://github.com/user-attachments/assets/0456a787-563d-4707-b700-e993385a87cd" />
