### PR TITLE
Refactor(client): home 화면 리페인트 최적화

### DIFF
--- a/apps/client/src/widgets/home/components/info-section/recommended-info-section.tsx
+++ b/apps/client/src/widgets/home/components/info-section/recommended-info-section.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from 'react';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
@@ -93,9 +92,7 @@ export const RecommendedInfoSection = ({
   userName,
 }: recommendedInfoSectionProps) => {
   const navigate = useNavigate();
-  const handleNavigateReport = useCallback(() => {
-    navigate(routePath.REPORT);
-  }, [navigate]);
+  const handleNavigateReport = () => navigate(routePath.REPORT);
 
   const { data: reportSummary } = useSuspenseQuery(
     HOME_QUERY_OPTIONS.REPORT_SUMMARY(),

--- a/apps/client/src/widgets/home/components/info-section/recommended-info-section.tsx
+++ b/apps/client/src/widgets/home/components/info-section/recommended-info-section.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useMemo } from 'react';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
@@ -15,37 +16,27 @@ import { StatusType } from '@shared/types/type.ts';
 
 import * as styles from './recommended-info-section.css.ts';
 
-interface recommendedInfoSectionProps {
+interface StaticContentProps {
   userName?: string;
+  productName?: string;
+  company?: string;
+  keywordChips?: string[];
 }
 
-/** 보험 추천받은 유저가 볼 화면 */
-export const RecommendedInfoSection = ({
+const StaticContent = ({
   userName,
-}: recommendedInfoSectionProps) => {
-  const navigate = useNavigate();
-  const handleNavigateReport = () => {
-    navigate(routePath.REPORT);
-  };
-
-  const { data: reportSummary } = useSuspenseQuery(
-    HOME_QUERY_OPTIONS.REPORT_SUMMARY(),
-  );
-  const targetToIconMap = new Map(
-    homeCardConfig.map(({ target, icon }) => [target, icon]),
-  );
-
-  if (!reportSummary) {
-    return;
-  }
-
+  productName,
+  company,
+  keywordChips,
+}: StaticContentProps) => {
   return (
-    <section className={styles.infoSection}>
+    <>
       <img
         src={'./3Dicon_background.webp'}
         width={223}
         height={185}
         className={styles.backgroundLogo}
+        alt=""
       />
       <div className={styles.titleSection}>
         <InsuranceSubtitle
@@ -58,11 +49,11 @@ export const RecommendedInfoSection = ({
         <InsuranceTitle
           fontColor={'white'}
           fontStyle={'eb_28'}
-          name={reportSummary.productName}
-          company={reportSummary.company}
+          name={productName}
+          company={company}
         />
         <div className={styles.chipList}>
-          {reportSummary.keywordChips?.map((chip, index) => (
+          {keywordChips?.map((chip, index) => (
             <Chip
               key={index}
               variant="round"
@@ -74,7 +65,58 @@ export const RecommendedInfoSection = ({
           ))}
         </div>
       </div>
+    </>
+  );
+};
 
+interface BottomButtonProps {
+  onClick: () => void;
+}
+
+const BottomButton = ({ onClick }: BottomButtonProps) => {
+  return (
+    <div className={styles.bottomButton}>
+      <TextButton color={'white'} size="sm" onClick={onClick}>
+        <p>구체적인 내용 확인하기</p>
+        <Icon name={'caret_right_md'} color="white" />
+      </TextButton>
+    </div>
+  );
+};
+
+interface recommendedInfoSectionProps {
+  userName?: string;
+}
+
+/** 보험 추천받은 유저가 볼 화면 */
+export const RecommendedInfoSection = ({
+  userName,
+}: recommendedInfoSectionProps) => {
+  const navigate = useNavigate();
+  const handleNavigateReport = useCallback(() => {
+    navigate(routePath.REPORT);
+  }, [navigate]);
+
+  const { data: reportSummary } = useSuspenseQuery(
+    HOME_QUERY_OPTIONS.REPORT_SUMMARY(),
+  );
+
+  const targetToIconMap = new Map(
+    homeCardConfig.map(({ target, icon }) => [target, icon]),
+  );
+
+  if (!reportSummary) {
+    return;
+  }
+
+  return (
+    <section className={styles.infoSection}>
+      <StaticContent
+        userName={userName}
+        productName={reportSummary.productName}
+        company={reportSummary.company}
+        keywordChips={reportSummary.keywordChips}
+      />
       <Carousel slidesPerView={4.5} autoPlay className={styles.homeCardList}>
         {reportSummary.statuses?.map((card, index) => (
           <Carousel.Item key={index}>
@@ -92,13 +134,7 @@ export const RecommendedInfoSection = ({
           </Carousel.Item>
         ))}
       </Carousel>
-
-      <div className={styles.bottomButton}>
-        <TextButton color={'white'} size="sm" onClick={handleNavigateReport}>
-          <p>구체적인 내용 확인하기</p>
-          <Icon name={'caret_right_md'} color="white" />
-        </TextButton>
-      </div>
+      <BottomButton onClick={handleNavigateReport} />
     </section>
   );
 };

--- a/apps/client/src/widgets/home/components/info-section/recommended-info-section.tsx
+++ b/apps/client/src/widgets/home/components/info-section/recommended-info-section.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 


### PR DESCRIPTION
## 📌 Summary

> close #481 

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

Carousel의 autoPlay 동작으로 인해 RecommendedInfoSection 전체가 매 프레임 업데이트 감지(Highlight) 되던 문제를 해결했습니다.
문제의 원인이 React 리렌더가 아닌 브라우저 repaint 범위 확장에 있음을 확인하고,
repaint 범위를 Carousel 영역으로 한정하도록 구조를 개선했습니다.


## 📚 Tasks

### 문제점

캐러셀의 autoPlay 기능이 캐러셀 렌더링만 담당하지 않고 Recommended-info-section 안에 있는 모든 컴포넌트에 대해서 React Profiler 의 rendering Highlight 에 계속 감지가 되는 문제가 있었습니다. 
이게 리렌더링인지, 리페인트인지 무한으로 highlight 되고 있어서 해당 문제를 해결해야겠다고 생각했어요. 

https://github.com/user-attachments/assets/294dd6cc-895c-436b-9f8f-b4b6e3f94851


### 문제 원인 파악

처음에는 리렌더링이 원인이라고 판단했어요. 그래서 리렌더링 여부를 확인하기 위해, 전체 부모 컴포넌트인 RecommendedInfoSection과 내부 요소인 InsuranceSubtitle에 console.count()를 찍어 렌더 횟수를 확인했습니다.

아래와 같이 매 프레임마다 count가 증가하지 않았고, 즉 매 프레임 리렌더링이 발생하는 상황이 아니라는 것을 먼저 확인할 수 있었어요.

<img width="1145" height="629" alt="스크린샷 2025-12-29 22 50 12" src="https://github.com/user-attachments/assets/8f6ef560-be5e-4aab-bc07-ef4d0e25e675" />


Profiler는 크게 다음을 보여줍니다.
- React가 Commit(=DOM 반영) 을 몇 번 수행했는지
- 각 Commit 과정에서 어떤 컴포넌트들이 render phase를 실행했는지
- 각 단계에서의 실행 시간(렌더링 비용)

Profiler에서 카운트가 계속 증가하는 것은 RecommendedInfoSection이 매 프레임 다시 렌더되고 있어서가 아니라, Carousel의 autoplay 애니메이션이 매 프레임 state 업데이트를 발생시키고 → 그 결과 React commit이 계속 일어나고 있었기 때문이었습니다.

즉, 

> 원래 코드 

```ts
<section className={styles.infoSection}>
  <img ... />
  <div className={styles.titleSection}>...</div>
  <Carousel>...</Carousel>  {/* transform 변경 */}
  <div className={styles.bottomButton}>...</div>
</section>
```

Carousel 의 transtform 이 변경되면 브라우저가 전체 section 을 하나의 페인팅 단위로 인식할 수 있어요. 
그래서 브라우저가 변경 범위를 정확히 구분하지 못해 전체 영역을 리페인트 할 수 있습니다. 

### 해결 방향 - repaint 범위 제한 

> 변경 코드 

```ts
<section className={styles.infoSection}>
  <StaticContent />      
  <Carousel>...</Carousel>  
  <BottomButton />       
</section>
```

다음과 같이 분리하여 각 컴포넌트가 독립적인 Fiber 노드가 되어 브라우저가 각 부분을 독립적인 레이어로 인식할 수 있도록 했어요. 

따라서 최적화의 목표를 리렌더를 줄이는 것이 아니라, Carousel 애니메이션으로 인해 발생하는 **repaint 범위를 최소화**하는 것 으로 바꾸었습니다. 

repaint 를 줄이기 위해 StaticContent, Carousel, BottomButton 등 역할 단위로 분리하여 
애니메이션이 발생하는 영역을 기준으로 브라우저가 자주 바뀌는 영역만 인식할 수 있도록 repaint 범위를 격리했어요. 

결과적으로 이전에는 모든 요소가 매 프레임 repaint 되었다면, 개선 이후에는 repaint 범위가 carousel 로 국한되면서 불필요한 화면 갱신 비용을 낮출 수 있었습니다. 


<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요시 .gif 형식으로 첨부해주세요.
-->

[As Is] 

https://github.com/user-attachments/assets/66fb8137-721b-4353-9533-cb62d3d9df73

[To-Be]

https://github.com/user-attachments/assets/6826273a-08b5-4c07-9605-4597e4c54dea



