### PR TITLE
Fix(client): 상세 페이지 진입 시 자동으로 댓글 작성 모드에 들어가지 않도록 수정

### DIFF
--- a/apps/client/src/widgets/community/components/comment-input-box/comment-input-box.tsx
+++ b/apps/client/src/widgets/community/components/comment-input-box/comment-input-box.tsx
@@ -41,6 +41,13 @@ const CommentInputBox = ({
   const { openModal, closeModal } = useModal();
 
   const replyCreateMode = mode.type === 'reply' && mode.action === 'create';
+
+  const handleFocus = () => {
+    if (mode.type === 'reset') {
+      dispatch({ type: 'COMMENT_CREATE' });
+    }
+  };
+
   useClickOutside(
     wrapperRef,
     () => dispatch({ type: 'RESET' }),
@@ -137,10 +144,11 @@ const CommentInputBox = ({
       <div className={styles.inputWrapper}>
         <Input
           key={focusKey}
-          autoFocus
+          autoFocus={mode.type !== 'reset'}
           value={value}
           onChange={onChange}
           onKeyDown={handleKeyDown}
+          onFocus={handleFocus}
           bgColor="white"
           placeholder={PLACEHOLDER.COMMENT}
           errorState={errorState}

--- a/apps/client/src/widgets/community/components/comment-input-box/comment-input-box.tsx
+++ b/apps/client/src/widgets/community/components/comment-input-box/comment-input-box.tsx
@@ -144,7 +144,7 @@ const CommentInputBox = ({
       <div className={styles.inputWrapper}>
         <Input
           key={focusKey}
-          autoFocus={mode.type !== 'reset'}
+          autoFocus={mode.type === 'comment' || mode.type === 'reply'}
           value={value}
           onChange={onChange}
           onKeyDown={handleKeyDown}

--- a/apps/client/src/widgets/community/components/detail-section/detail-section.tsx
+++ b/apps/client/src/widgets/community/components/detail-section/detail-section.tsx
@@ -31,10 +31,7 @@ const DetailSection = ({ postId }: DetailSectionProps) => {
   const queryClient = useQueryClient();
 
   useEffect(() => {
-    const isStillCreatingMode =
-      prevModeRef.current.action === 'create' && mode.action === 'create';
-    const typeChanged = prevModeRef.current.type !== mode.type;
-
+    const prev = prevModeRef.current;
     prevModeRef.current = mode;
 
     if (mode.type === 'comment' && mode.action === 'edit') {
@@ -72,7 +69,12 @@ const DetailSection = ({ postId }: DetailSectionProps) => {
       return;
     }
 
-    if (isStillCreatingMode && typeChanged) {
+    const shouldPreserveImage =
+      (prev.type === 'reset' && mode.action === 'create') ||
+      (prev.action === 'create' && mode.type === 'reset') ||
+      (prev.action === 'create' && mode.action === 'create');
+
+    if (shouldPreserveImage) {
       return;
     }
 

--- a/apps/client/src/widgets/community/components/detail-section/detail-section.tsx
+++ b/apps/client/src/widgets/community/components/detail-section/detail-section.tsx
@@ -338,7 +338,6 @@ const DetailSection = ({ postId }: DetailSectionProps) => {
     <>
       <FeedContent postId={postId} />
       <CommentInputBox
-        key={focusKey}
         value={content}
         onChange={handleChange}
         errorState={isErrorState}

--- a/apps/client/src/widgets/community/context/input-mode-context.tsx
+++ b/apps/client/src/widgets/community/context/input-mode-context.tsx
@@ -3,7 +3,6 @@ import {
   Dispatch,
   ReactNode,
   useContext,
-  useEffect,
   useMemo,
   useReducer,
 } from 'react';
@@ -36,14 +35,10 @@ export const InputModeContextProvider = ({
   };
 
   const [mode, dispatch] = useReducer(reducer, {
-    type: 'comment',
-    action: 'create',
-    postId,
+    type: 'reset',
+    action: 'reset',
   } as const);
 
-  useEffect(() => {
-    dispatch({ type: 'RESET' });
-  }, [postId]);
   const value = useMemo(() => ({ mode, dispatch }), [mode]);
   return (
     <InputModeContext.Provider value={value}>

--- a/apps/client/src/widgets/community/hooks/create-input-mode-reducer.ts
+++ b/apps/client/src/widgets/community/hooks/create-input-mode-reducer.ts
@@ -15,6 +15,12 @@ export const createInputModeReducer = ({
   action,
 }: ComposeModeReducerType): InputBoxMode => {
   switch (action.type) {
+    case 'COMMENT_CREATE':
+      return {
+        type: 'comment',
+        action: 'create',
+        postId,
+      } as const;
     case 'COMMENT_EDIT':
       return {
         type: 'comment',
@@ -68,6 +74,6 @@ export const createInputModeReducer = ({
 
     case 'RESET':
     default:
-      return { type: 'comment', action: 'create', postId } as const;
+      return { type: 'reset', action: 'reset' } as const;
   }
 };

--- a/apps/client/src/widgets/community/hooks/use-controll-input-box.ts
+++ b/apps/client/src/widgets/community/hooks/use-controll-input-box.ts
@@ -1,28 +1,19 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { InputBoxMode } from '@widgets/community/types/input-box-type';
 
 import { LIMIT_SHORT_TEXT } from '@shared/constants/text-limits';
 
 export const useControlledInputBox = (mode: InputBoxMode) => {
-  const [content, setContent] = useState(
-    'initialContent' in mode ? mode.initialContent : '',
-  );
-  const prevModeRef = useRef(mode);
+  const [content, setContent] = useState('');
+
+  const initialContent = 'initialContent' in mode ? mode.initialContent : null;
 
   useEffect(() => {
-    const isStillCreatingMode =
-      prevModeRef.current.action === 'create' && mode.action === 'create';
-    const typeChanged = prevModeRef.current.type !== mode.type;
-
-    prevModeRef.current = mode;
-
-    if (isStillCreatingMode && typeChanged) {
-      return;
+    if (initialContent !== null) {
+      setContent(initialContent);
     }
-
-    setContent('initialContent' in mode ? mode.initialContent : '');
-  }, [mode]);
+  }, [initialContent]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const next = e.target.value;
@@ -32,7 +23,7 @@ export const useControlledInputBox = (mode: InputBoxMode) => {
   };
 
   const reset = () => {
-    setContent('initialContent' in mode ? mode.initialContent : '');
+    setContent('');
   };
 
   return { content, handleChange, reset };

--- a/apps/client/src/widgets/community/types/input-box-type.ts
+++ b/apps/client/src/widgets/community/types/input-box-type.ts
@@ -1,6 +1,7 @@
 import { Image } from '@shared/types/type.ts';
 
 export type InputBoxMode =
+  | { type: 'reset'; action: 'reset' }
   | { type: 'comment'; action: 'create'; postId: string; images?: Image[] }
   | {
       type: 'comment';
@@ -24,6 +25,7 @@ export type InputBoxMode =
     };
 
 export type ReducerAction =
+  | { type: 'COMMENT_CREATE' }
   | {
       type: 'COMMENT_EDIT';
       commentId: number;


### PR DESCRIPTION
## 📌 Summary

> - #493 
- 상세 페이지 진입 시 자동으로 댓글 작성 모드에 들어가지 않도록 수정
- `useControlledInputBox` 훅 간소화

## 📚 Tasks
기존에 상세 페이지 마운트 시 댓글 작성 모드가 활성화 되어 inputBox가 autoFocus되었어요. 이번 QA때 상세 페이지 진입 시 자동으로 autoFocus되는 것을 막아달라는 요청이 들어와서 처음 진입 시 reset 상태가 되도록 수정했습니다.

작업 내용은 아래와 같아요.
detail페이지 진입 시 reset모드로 진입되도록 했어요. 기존에는 reset상태가 comment, create 즉, 댓글 작성 모드였는데 reset 모드를 온전한 reset 상태로 수정하고 `COMMENT_CREATE` 액션을 따로 추가하여 reset상태와 create상태를 분리했어요.

추가로 `useControlledInputBox` 커스텀 훅을 간소화 했어요.
기존에 mode 변경 시마다 복잡한 조건으로 content 초기화 여부 결정하고 특정 모드 전환마다 예외 케이스 추가 필요했었어요. 급하게 작업 하다보니 불필요한 조건문도 사용하게 됐던것 같아요.
그래서 불필요한 부분들을 다 제거했고 `initialContent` 즉, 기존 inputBox내 내용이 변경될 때만 content를 설정하도록 변경했어요.
<!--
## 👀 To Reviewer

(기재 내용 없을 경우 섹션 삭제) 더 전달할 내용 혹은 리뷰에게 요청하는 내용을 작성해주세요.
-->

<!--
## 🕶️ Requirements Checklist
- [ ]

(기능 명세서상 내용을 복사해서 테스트해주세요)
-->

## 📸 Screenshot
### [AS-IS]

https://github.com/user-attachments/assets/1cb1eb03-01e8-4543-b0b4-10800ca18dcd

### [TO-BE]

https://github.com/user-attachments/assets/68f45545-3ecc-4885-bc87-a31c5935d82a