### PR TITLE
Refactor(client): 데이터 로딩 중 레이아웃 시프트 개선

### DIFF
--- a/apps/client/src/widgets/community/components/feed-list/feed-list.tsx
+++ b/apps/client/src/widgets/community/components/feed-list/feed-list.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
 import { Chip, TextButton } from '@bds/ui';
@@ -34,7 +34,7 @@ const FeedList = () => {
   }, true);
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useInfiniteQuery({
+    useSuspenseInfiniteQuery({
       ...COMMUNITY_QUERY_OPTIONS.POSTS(sort.value, category),
     });
 

--- a/apps/client/src/widgets/community/components/live-popular-feed/live-popular-feed.tsx
+++ b/apps/client/src/widgets/community/components/live-popular-feed/live-popular-feed.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
 import { Carousel, Indicator, Title } from '@bds/ui';
@@ -17,7 +17,7 @@ const TOTAL_POPULAR_FEED = 3;
 const LivePopularFeed = () => {
   const navigate = useNavigate();
   const [currentPage, setCurrentPage] = useState(0);
-  const { data: popularFeedData } = useQuery({
+  const { data: popularFeedData } = useSuspenseQuery({
     ...COMMUNITY_QUERY_OPTIONS.POPULAR_FEED(TOTAL_POPULAR_FEED),
   });
   return (


### PR DESCRIPTION
## 📌 Summary

> close #495 

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

## 📚 Tasks

- _해당 PR에 수행한 작업을 작성해주세요._

커뮤니티 내부에서 인기 게시물 데이터가 상대적으로 느리게 로드될 경우,
해당 섹션이 일시적으로 비어 보였다가 나중에 채워지는 레이아웃 다닥임(Layout Shift) 문제가 발생하고 있었어요.

https://github.com/user-attachments/assets/38b41123-223d-4c53-833d-acaf9490f4f6

인기 게시물 섹션이 useQuery 기반으로 데이터 패칭을 하고 있어 초기 렌더 시 data === undefined 상태로 먼저 UI가 렌더링된 뒤,
데이터 주입 시점에 레이아웃이 변경되는 구조이기 때문에 초기 진입 시에는 레이아웃 시프트를 유저가 볼 수 있다는 문제였어요. 

### 해결 방법 

**인기 게시물 섹션**
`useQuery` → `useSuspenseQuery` 로 변경

**커뮤니티 post 리스트**
`useInfiniteQuery` → `useSuspenseInfiniteQuery` 로 변경

지금 현재 프로젝트 구조가 인기 게시물 section 과, 커뮤니티 post section 이 전체 suspense boundary 에 감싸져 있는 형태이기 때문에
두 API 모두 Suspense 기반으로 통일해서, 모든 데이터가 준비된 이후에 한 번에 완성된 UI가 렌더링되도록 개선했어요.

###  [TO - BE]

https://github.com/user-attachments/assets/f6fc89d5-73a2-40cb-ac6a-7948149e318a


